### PR TITLE
issue #33: uninstaller cwd fix and removal of reconcile_hosts from goldstone_init

### DIFF
--- a/goldstone/core/tests_resource_api.py
+++ b/goldstone/core/tests_resource_api.py
@@ -78,9 +78,10 @@ class CoreResourceTypes(Setup):
                 HTTP_AUTHORIZATION=AUTHORIZATION_PAYLOAD % token)
 
         # Test the result.
-        self.assertContains(response,
-                            '{"nodes":[],"edges":[]}',
-                            status_code=HTTP_200_OK)
+        # pylint: disable=E1101
+        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(json.loads(response.content),
+                         {"nodes": [], "edges": []})
 
     def test_mix(self):
         """The resource type graph is populated with a mixture of types, some
@@ -525,9 +526,10 @@ class CoreResources(Setup):
                 HTTP_AUTHORIZATION=AUTHORIZATION_PAYLOAD % token)
 
         # Test the result.
-        self.assertContains(response,
-                            '{"nodes":[],"edges":[]}',
-                            status_code=HTTP_200_OK)
+        # pylint: disable=E1101
+        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(json.loads(response.content),
+                         {"nodes": [], "edges": []})
 
     def test_mix(self):
         """The resource graph is populated with a mixture of nodes."""

--- a/goldstone/core/tests_resource_api_query_strings.py
+++ b/goldstone/core/tests_resource_api_query_strings.py
@@ -69,25 +69,18 @@ class CoreResources(Setup):
         mock_r_graph = Resources()
         mock_r_graph.graph.clear()
 
-        # Test one filter.
+        # Test one filter, and two filters.
         with patch("goldstone.core.views.resources", mock_r_graph):
-            response = self.client.get(
-                RES_URL_FILTER % "native_id=fred",
-                HTTP_AUTHORIZATION=AUTHORIZATION_PAYLOAD % token)
+            for filters in ["native_id=fred",
+                            "integration_name=%5enova&native_id=fred"]:
+                response = self.client.get(
+                    RES_URL_FILTER % filters,
+                    HTTP_AUTHORIZATION=AUTHORIZATION_PAYLOAD % token)
 
-        self.assertContains(response,
-                            '{"nodes":[],"edges":[]}',
-                            status_code=HTTP_200_OK)
-
-        # Test two filters.
-        with patch("goldstone.core.views.resources", mock_r_graph):
-            response = self.client.get(
-                RES_URL_FILTER % "integration_name=%5enova&native_id=fred",
-                HTTP_AUTHORIZATION=AUTHORIZATION_PAYLOAD % token)
-
-        self.assertContains(response,
-                            '{"nodes":[],"edges":[]}',
-                            status_code=HTTP_200_OK)
+                # pylint: disable=E1101
+                self.assertEqual(response.status_code, HTTP_200_OK)
+                self.assertEqual(json.loads(response.content),
+                                 {"nodes": [], "edges": []})
 
     def test_mix(self):
         """The resource graph is populated with a mixture of nodes."""

--- a/goldstone/nova/tasks.py
+++ b/goldstone/nova/tasks.py
@@ -182,7 +182,8 @@ def reconcile_hosts():
 
     hosts = get_nova_host_list()
     incoming = frozenset([host.host_name for host in hosts])
-    incoming = frozenset([parse_host_name(name) for name in incoming])
+    incoming = frozenset([parse_host_name(host_name)
+                          for host_name in incoming])
     incoming_names = frozenset([item[0] for item in incoming])
     existing_names = frozenset([host.name for host in Host.objects.all()])
 
@@ -191,14 +192,14 @@ def reconcile_hosts():
     missing = existing_names.difference(incoming_names)
 
     # delete missing hosts from our model
-    for name in missing:
-        Host.objects.filter(name=name).delete()
+    for host_name in missing:
+        Host.objects.filter(native_name=host_name).delete()
 
     # create new hosts in our model
-    for name in new:
+    for host_name in new:
         Host.objects.create(
-            name=name,
-            fqdn=[item[1] for item in incoming if item[0] == name][0])
+            native_name=host_name,
+            fqdn=[item[1] for item in incoming if item[0] == host_name][0])
 
 
 def get_nova_host_list():

--- a/goldstone/utils.py
+++ b/goldstone/utils.py
@@ -44,15 +44,7 @@ class GoldstoneAuthError(GoldstoneBaseException):
     pass
 
 
-class NoDailyIndex(GoldstoneBaseException):
-    pass
-
-
 class NoResourceFound(GoldstoneBaseException):
-    pass
-
-
-class UnexpectedSearchResponse(GoldstoneBaseException):
     pass
 
 

--- a/installer_fabfile.py
+++ b/installer_fabfile.py
@@ -155,16 +155,6 @@ def _collect_static(proj_settings, install_dir):
                            install_dir=install_dir)
 
 
-def _reconcile_hosts(proj_settings, install_dir):
-    """Build the initial entries in the Hosts table from agg of loggers."""
-
-    with _django_env(proj_settings, install_dir):
-        from goldstone.nova.tasks import reconcile_hosts
-
-        print(green("Collecting information about Openstack resources."))
-        reconcile_hosts()
-
-
 @task
 def install_repos():
     """Sets up yum repos used by goldstone installer."""
@@ -629,7 +619,6 @@ def goldstone_init(django_admin_user='admin',    # pylint: disable=R0913
                settings)
 
     _collect_static(settings, install_dir)
-    _reconcile_hosts(settings, install_dir)
     _configure_services()
     load_es_templates(proj_settings=settings)
 
@@ -729,9 +718,6 @@ def uninstall(dropdb=True, dropuser=True):
             local('systemctl stop celerybeat.service')
             local('systemctl disable celerybeat.service')
 
-    with fab_settings(warn_only=True):
-        local('yum remove -y goldstone-server')
-
     if dropdb:
         with fab_settings(warn_only=True):
             local('su - postgres -c \'dropdb goldstone\'')
@@ -741,3 +727,6 @@ def uninstall(dropdb=True, dropuser=True):
 
             local('systemctl stop postgresql.service')
             local('systemctl disable postgresql.service')
+
+    with fab_settings(warn_only=True):
+        local('yum remove -y goldstone-server')


### PR DESCRIPTION
removed the reconcile_hosts call to make the installer more resilient.
it should not fail if the cloud API is not available.  reconciliation
will occur via celery tasks which should be able to handle a cloud API
outage. also fixed a field name error in reconcile_hosts Host calls.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/solinea/goldstone-server/34)
<!-- Reviewable:end -->
