### PR TITLE
automatic token expiration

### DIFF
--- a/goldstone/core/tasks.py
+++ b/goldstone/core/tasks.py
@@ -66,11 +66,11 @@ def update_persistent_graph():
 def expire_auth_tokens():
     """Expire authorization tokens.
 
-    Currently, this deletes all existing tokens, which will force every user to
-    log in again.
+    This deletes all existing tokens, which will force every user to log in
+    again.
 
-    This should be replaced with using djangorestframwork-timed-auth-token
-    after we upgrade to Django 1.8.
+    This should be replaced with djangorestframwork-timed-auth-token after we
+    upgrade to Django 1.8.
 
     """
     from rest_framework.authtoken.models import Token

--- a/goldstone/core/tasks.py
+++ b/goldstone/core/tasks.py
@@ -60,3 +60,19 @@ def update_persistent_graph():
     update_keystone_nodes()
     update_nova_nodes()
     update_cinder_nodes()
+
+
+@celery_app.task()
+def expire_auth_tokens():
+    """Expire authorization tokens.
+
+    Currently, this deletes all existing tokens, which will force every user to
+    log in again.
+
+    This should be replaced with using djangorestframwork-timed-auth-token
+    after we upgrade to Django 1.8.
+
+    """
+    from rest_framework.authtoken.models import Token
+
+    Token.objects.all().delete()

--- a/goldstone/nova/test_views.py
+++ b/goldstone/nova/test_views.py
@@ -162,6 +162,7 @@ class SpawnsViewTests(BaseTest):
 
 
 class DataViewTests(SimpleTestCase):
+    """Test the non-hypervisor nova/ URLs."""
 
     def setUp(self):
         """Run before every test."""
@@ -170,6 +171,7 @@ class DataViewTests(SimpleTestCase):
         self.token = create_and_login()
 
     def _evaluate(self, response):
+        """Evalute test results."""
 
         self.assertIsInstance(response, HttpResponse)
         self.assertIsNotNone(response.content)
@@ -183,6 +185,10 @@ class DataViewTests(SimpleTestCase):
             self.assertIsInstance(j, list)
             self.assertGreaterEqual(len(j), 1)
             self.assertIsInstance(j[0], list)
+
+    # Disabling pylint's docstring check, because the remaining methods are
+    # cookie-cutter.
+    # pylint: disable=C0111
 
     def test_get_agents(self):
         self._evaluate(self.client.get(

--- a/goldstone/settings/base.py
+++ b/goldstone/settings/base.py
@@ -223,6 +223,10 @@ CELERYBEAT_SCHEDULE = {
         'task': 'goldstone.core.tasks.update_persistent_graph',
         'schedule': TOPOLOGY_QUERY_INTERVAL
     },
+    'expire_auth_tokens': {
+        'task': 'goldstone.core.tasks.expire_auth_tokens',
+        'schedule': crontab(hour=0, minute=0)     # execute daily at midnight
+    },
 }
 
 # Database row settings.


### PR DESCRIPTION
Pylint:
* master: 9.54 / 10 / 9.7
* this pull: 9.57 / 10 / 9.7

This fulfills the "automatic token expiration" ticket. More or less. :-)

The [package to use for DRF token expiration](https://pypi.python.org/pypi/djangorestframework-timed-auth-token/) requires Django 1.8 and Python 3. The Python 3 requirement appears to be a no-op, but the Django 1.8 requirement is a roadblock because of incompatibilities between its migrations files and the version of South that we use.  After we upgrade to Django 1.8, we should try again to use this package, as it will give us finer-grained token expiration than this pull request.

This pull request uses a daily celery task that deletes all authorization tokens. So, users will have to log in once per day. If a longer token lifespan is desired, the settings.base.CELERYBEAT_SCHEDULE.expire_auth_tokens entry just needs to be edited.

This has all the corner cases you'd expect to find in a delete-all-tokens-at-midnight scheme.  But it will give us simple token expiration today.

This does not implement the "delete all tokens when an application is added" requirement, because the module loading hasn't been implemented yet.