### PR TITLE
Opentrail resource type and resource graph nodes

### DIFF
--- a/addon_fabfile.py
+++ b/addon_fabfile.py
@@ -71,7 +71,7 @@ CELERYBEAT_APPS = \
 CELERYBEAT_APP_INCLUDE = \
     "# Tasks for {0}.\n" \
     "from {0}.settings import CELERYBEAT_SCHEDULE as {0}_celerybeat\n" \
-    "CELERYBEAT_SCHEDULE.update({0}_celerybeat)\n\n"
+    "CELERYBEAT_SCHEDULE.update({0}_celerybeat)\n"
 
 
 @contextmanager
@@ -298,7 +298,7 @@ def _install_addon_info(name, install_dir):           # pylint: disable=R0914
             CELERYBEAT_APP_INCLUDE.format(name)
 
         javascript_changes = \
-            "We'll copy {0}/*.* to {1}/*.*, and add this line to " \
+            "\nWe'll copy {0}/*.* to {1}/*.*, and add this line to " \
             "base.html:\n".format(addon_install["static_source"],
                                   addon_install["static_dest"])
         javascript_changes = \

--- a/goldstone/addons/tests.py
+++ b/goldstone/addons/tests.py
@@ -3,6 +3,7 @@
 Tests:
     /addons/
     /addons/verify/
+    .utils.update_addon_nodes
 
 """
 # Copyright 2015 Solinea, Inc.
@@ -22,9 +23,13 @@ import json
 from mock import Mock, patch
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 
+from goldstone.core.models import PolyResource, Image, Server, ServerGroup, \
+    NovaLimits
+from goldstone.core.tests import NODE_TYPES, load_persistent_rg
 from goldstone.test_utils import Setup, create_and_login, \
     AUTHORIZATION_PAYLOAD
-from .models import Addon
+from .models import Addon as AddonTable
+from .utils import update_addon_nodes
 
 # URLs for the tests.
 APP_URL = "/addons/"
@@ -33,12 +38,6 @@ VERIFY_URL = APP_URL + "verify/"
 
 class Addons(Setup):
     """The returning of information about user-installed add-ons."""
-
-    def setUp(self):
-        """Run before every test."""
-
-        super(Addons, self).setUp()
-        Addon.objects.all().delete()
 
     def test_none(self):
         """No add-ons are installed."""
@@ -59,16 +58,16 @@ class Addons(Setup):
         """Some add-ons are installed."""
 
         # Create two Addon rows.
-        app1 = Addon.objects.create(name="test1",
-                                    version="1.001",
-                                    manufacturer="Foonly, Inc.",
-                                    url_root="dolphin",
-                                    notes="test application")
-        app2 = Addon.objects.create(name="test2",
-                                    version="2.a(4)",
-                                    manufacturer="Solinea",
-                                    url_root="test2",
-                                    notes="another test application")
+        app1 = AddonTable.objects.create(name="test1",
+                                         version="1.001",
+                                         manufacturer="Foonly, Inc.",
+                                         url_root="dolphin",
+                                         notes="test application")
+        app2 = AddonTable.objects.create(name="test2",
+                                         version="2.a(4)",
+                                         manufacturer="Solinea",
+                                         url_root="test2",
+                                         notes="another test application")
 
         # Create a user.
         token = create_and_login()
@@ -110,7 +109,7 @@ class AddonsVerify(Setup):
         """Run before every test."""
 
         super(AddonsVerify, self).setUp()
-        Addon.objects.all().delete()
+        AddonTable.objects.all().delete()
 
     def test_none(self):
         """No add-ons are installed."""
@@ -131,16 +130,16 @@ class AddonsVerify(Setup):
         """Some add-ons are installed, and they all are bad."""
 
         # Create two Addon rows.
-        app1 = Addon.objects.create(name="test1",
-                                    version="1.001",
-                                    manufacturer="Foonly, Inc.",
-                                    url_root="dolphin",
-                                    notes="test application")
-        app2 = Addon.objects.create(name="test2",
-                                    version="2.a(4)",
-                                    manufacturer="Solinea",
-                                    url_root="test2",
-                                    notes="another test application")
+        app1 = AddonTable.objects.create(name="test1",
+                                         version="1.001",
+                                         manufacturer="Foonly, Inc.",
+                                         url_root="dolphin",
+                                         notes="test application")
+        app2 = AddonTable.objects.create(name="test2",
+                                         version="2.a(4)",
+                                         manufacturer="Solinea",
+                                         url_root="test2",
+                                         notes="another test application")
 
         # Create a user.
         token = create_and_login()
@@ -169,21 +168,21 @@ class AddonsVerify(Setup):
                 raise Resolver404
 
         # Create three Addon rows.
-        app1 = Addon.objects.create(name="test1",
-                                    version="1.001",
-                                    manufacturer="Foonly, Inc.",
-                                    url_root="dolphin",
-                                    notes="test application")
-        app2 = Addon.objects.create(name="test2",
-                                    version="2.a(4)",
-                                    manufacturer="Solinea",
-                                    url_root="test2",
-                                    notes="another test application")
-        Addon.objects.create(name="test3",
-                             version="45",
-                             manufacturer="Mozilla",
-                             url_root="test3",
-                             notes="the real mccoy")
+        app1 = AddonTable.objects.create(name="test1",
+                                         version="1.001",
+                                         manufacturer="Foonly, Inc.",
+                                         url_root="dolphin",
+                                         notes="test application")
+        app2 = AddonTable.objects.create(name="test2",
+                                         version="2.a(4)",
+                                         manufacturer="Solinea",
+                                         url_root="test2",
+                                         notes="another test application")
+        AddonTable.objects.create(name="test3",
+                                  version="45",
+                                  manufacturer="Mozilla",
+                                  url_root="test3",
+                                  notes="the real mccoy")
 
         # Make the thrid "good" by mocking out the Django URL resolver.
         mock_resolver = Mock()
@@ -211,21 +210,21 @@ class AddonsVerify(Setup):
         """Some add-ons are installed, and all are good."""
 
         # Create three Addon rows.
-        Addon.objects.create(name="test1",
-                             version="1.001",
-                             manufacturer="Foonly, Inc.",
-                             url_root="dolphin",
-                             notes="test application")
-        Addon.objects.create(name="test2",
-                             version="2.a(4)",
-                             manufacturer="Solinea",
-                             url_root="test2",
-                             notes="another test application")
-        Addon.objects.create(name="test3",
-                             version="45",
-                             manufacturer="Mozilla",
-                             url_root="test3",
-                             notes="the real mccoy")
+        AddonTable.objects.create(name="test1",
+                                  version="1.001",
+                                  manufacturer="Foonly, Inc.",
+                                  url_root="dolphin",
+                                  notes="test application")
+        AddonTable.objects.create(name="test2",
+                                  version="2.a(4)",
+                                  manufacturer="Solinea",
+                                  url_root="test2",
+                                  notes="another test application")
+        AddonTable.objects.create(name="test3",
+                                  version="45",
+                                  manufacturer="Mozilla",
+                                  url_root="test3",
+                                  notes="the real mccoy")
 
         # Make all of them "good" apps by mocking out the Django URL resolver.
         mock_resolver = Mock()
@@ -240,3 +239,134 @@ class AddonsVerify(Setup):
 
         # Test the result.  No bad rows = empty list returned.
         self.assertContains(response, "[]", status_code=HTTP_200_OK)
+
+
+class UpdateAddonNodes(Setup):
+    """Test utils.update_addon_nodes."""
+
+    def setUp(self):
+        """Run before every test."""
+
+        super(UpdateAddonNodes, self).setUp()
+
+        for nodetype in NODE_TYPES:
+            nodetype.objects.all().delete()
+
+    def test_empty_rg_empty_table(self):
+        """Nothing in the resource graph, nothing in the Addon table.
+
+        Nothing should be done.
+
+        """
+
+        update_addon_nodes()
+
+        self.assertEqual(PolyResource.objects.count(), 0)
+
+    def test_rg_empty_cloud_image(self):
+        """The resource graph contains some nodes; nothing in the Addon table.
+
+        Nothing should be done.
+
+        """
+
+        # The initial resource graph nodes, as (Type, native_id) tuples.
+        NODES = [(Image, "a"), (Image, "ab"), (Image, "abc")]
+
+        # The initial resource graph edges. Each entry is ((from_type,
+        # native_id), (to_type, native_id)).
+        EDGES = [((Image, "a"), (Image, "ab")), ((Image, "abc"), (Image, "a"))]
+
+        # Create the PolyResource database rows.
+        load_persistent_rg(NODES, EDGES)
+        rowcount = PolyResource.objects.count()
+
+        update_addon_nodes()
+
+        self.assertEqual(PolyResource.objects.count(), rowcount)
+
+    def test_empty_rg_cloud_multi(self):
+        """Nothing in the resource graph; some rows in the Addon table.
+
+        The Addon rows should be added to the graph.
+
+        """
+
+        # Test data.
+        DATA = [{"name": "this addon",
+                 "version": "42",
+                 "manufacturer": "Lynbrook Senior High School",
+                 "url_root": "lynbrook"},
+                {"name": "that addon",
+                 "version": "4",
+                 "manufacturer": "Lynbrook North Junior High School",
+                 "url_root": "lynbrook/2"},
+                {"name": "the other addon",
+                 "version": "4.2(0)",
+                 "manufacturer": "West End Elementary School",
+                 "url_root": "lynbrook/3/"},
+                ]
+
+        # Load up the Addon table.
+        for entry in DATA:
+            AddonTable.objects.create(**entry)
+
+        update_addon_nodes()
+
+        self.assertEqual(PolyResource.objects.count(), len(DATA))
+
+    def test_rg_cloud_hit(self):
+        """Something is in the graph, and Addon rows exist.
+
+        The Addon rows should be added to the graph.
+
+        """
+
+        # The initial resource graph nodes, as (Type, native_id) tuples.  The
+        # native_id's must be unique within a node type.
+        NODES = [(Image, "a"),
+                 (Image, "ab"),
+                 (Image, "abc"),
+                 (Server, "ab"),
+                 (ServerGroup, "0"),
+                 (ServerGroup, "ab"),
+                 (NovaLimits, "0")]
+
+        # The initial resource graph edges. Each entry is ((from_type,
+        # native_id), (to_type, native_id)).  The native_id's must be unique
+        # within a node type. N.B. Some of these edges would not exist in a
+        # running system, because they're not defined in Types.
+        EDGES = [((Image, "a"), (Image, "ab")),
+                 ((Image, "a"), (ServerGroup, "0")),
+                 ((Image, "ab"), (ServerGroup, "ab")),
+                 ((Image, "ab"), (Image, "abc")),
+                 ((NovaLimits, "0"), (ServerGroup, "ab")),
+                 ((NovaLimits, "0"), (Image, "a")),
+                 ((ServerGroup, "0"), (NovaLimits, "0")),
+                 ]
+
+        # Create the PolyResource database rows.
+        load_persistent_rg(NODES, EDGES)
+
+        # Test data.
+        DATA = [{"name": "this addon",
+                 "version": "42",
+                 "manufacturer": "Lynbrook Senior High School",
+                 "url_root": "lynbrook"},
+                {"name": "that addon",
+                 "version": "4",
+                 "manufacturer": "Lynbrook North Junior High School",
+                 "url_root": "lynbrook/2"},
+                {"name": "the other addon",
+                 "version": "4.2(0)",
+                 "manufacturer": "West End Elementary School",
+                 "url_root": "lynbrook/3/"},
+                ]
+
+        # Load up the Addon table.
+        for entry in DATA:
+            AddonTable.objects.create(**entry)
+
+        update_addon_nodes()
+
+        self.assertEqual(PolyResource.objects.count(), len(DATA) + len(NODES))

--- a/goldstone/addons/utils.py
+++ b/goldstone/addons/utils.py
@@ -38,10 +38,8 @@ def update_addon_nodes():
             # persistent data.
             entry.delete()
 
-    # For every Addon table entry, add it to the persistent Resource graph if
+    # For every Addon table row, add it to the persistent resource graph if
     # it's not there.
-    #
-    # For every Addon row...
     for row in AddonTable.objects.all():
         # Try to find its corresponding persistent Resource graph node.
         if not Addon.objects.filter(native_name=row.name).exists():
@@ -50,7 +48,6 @@ def update_addon_nodes():
                                  native_name=row.name,
                                  cloud_attributes=model_to_dict(row))
 
-    # New add-on nodes have been added. Now fill in / update all nodes'
-    # outgoing edges.
+    # Now fill in / update all nodes' outgoing edges.
     for node in PolyResource.objects.all():
         node.update_edges()

--- a/goldstone/addons/utils.py
+++ b/goldstone/addons/utils.py
@@ -1,0 +1,58 @@
+"""Add-on utilities."""
+# Copyright 2015 Solinea, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def update_addon_nodes():
+    """Update the Resource graph's add-on nodes and edges from the current
+    Addon table.
+
+    Nodes are:
+       - deleted if they are no longer in the Addon table
+       - added if they are in the Addon table, but not in the graph.
+       - updated from the Addon table if they are already in the graph.
+
+    """
+    from goldstone.addons.models import Addon as AddonTable
+    from goldstone.core.models import PolyResource, Addon
+
+    # Remove Resource graph nodes that no longer exist.
+    actual_names = set(x.name for x in AddonTable.objects.all())
+
+    # For every node of this type in the persistent resource graph...
+    for entry in Addon.objects.all():
+        if entry.native_name not in actual_names:
+            # This node isn't in the cloud anymore, so delete it from the
+            # persistent data.
+            entry.delete()
+
+    # For every Addon table entry, add it to the persistent Resource graph if
+    # it's not there.
+    #
+    # For every Addon row...
+    for row in AddonTable.objects.all():
+        # Try to find its corresponding persistent Resource graph node.
+        if not Addon.objects.filter(native_name=row.name).exists():
+            # The node doesn't exist. Create it.
+            Addon.objects.create(native_id=row.name,
+                                 native_name=row.name,
+                                 cloud_attributes=row.to_dict())
+
+    # New add-on nodes have been added. Now fill in / update all nodes'
+    # outgoing edges.
+    #
+    # TODO: Perhaps make this a table Manager method, to hide the loop &
+    # optimize it.
+    for node in PolyResource.objects.all():
+        node.update_edges()

--- a/goldstone/addons/utils.py
+++ b/goldstone/addons/utils.py
@@ -24,6 +24,7 @@ def update_addon_nodes():
        - updated from the Addon table if they are already in the graph.
 
     """
+    from django.forms.models import model_to_dict
     from goldstone.addons.models import Addon as AddonTable
     from goldstone.core.models import PolyResource, Addon
 
@@ -47,12 +48,9 @@ def update_addon_nodes():
             # The node doesn't exist. Create it.
             Addon.objects.create(native_id=row.name,
                                  native_name=row.name,
-                                 cloud_attributes=row.to_dict())
+                                 cloud_attributes=model_to_dict(row))
 
     # New add-on nodes have been added. Now fill in / update all nodes'
     # outgoing edges.
-    #
-    # TODO: Perhaps make this a table Manager method, to hide the loop &
-    # optimize it.
     for node in PolyResource.objects.all():
         node.update_edges()

--- a/goldstone/core/models.py
+++ b/goldstone/core/models.py
@@ -249,7 +249,24 @@ class PolyResource(PolymorphicModel):
 
     @classmethod
     def outgoing_edges(cls):      # pylint: disable=R0201
-        """Return the edges leaving this type (not instance!)."""
+        """Return the edges leaving this type (not instance!).
+
+        :return: Entries in the form of:
+                 TO: The destination type
+                 MATCHING_FN: Callable(from_attr_dict, to_attr_dict).  If
+                              there's a match between the from_node's and
+                              to_node's attribute dicts, we draw a Resource
+                              graph edge. Note: This must be prepared for
+                              absent keys, and not throw exceptions.
+                 EDGE_ATTTRIBUTES: This edge's attributes:
+                     TYPE: The type of this edge
+                     MIN: A resource graph node has a minimum number of this
+                          edge ntype
+                     MAX: A resource graph node has a maximum number of this
+                          edge type
+        :rtype: list of dict
+
+        """
 
         return []
 
@@ -301,9 +318,32 @@ class PolyResource(PolymorphicModel):
         return LogEvent.search().query(name_query)
 
 
-#
-# These classes represent entities within a Keystone integration.
-#
+############################################
+# These classes represent add-on entities. #
+############################################
+
+
+class Addon(PolyResource):
+    """The root node for user-installed Goldstone add-ons."""
+
+    @classmethod
+    def clouddata(cls):
+        """See the parent class' method's docstring."""
+
+        return [x.cloud_attributes for x in Addon.objects.all()]
+
+    @classmethod
+    def display_attributes(cls):
+        """Return a dict of cloud information about this type, suitable for
+        client display."""
+
+        return {"integration_name": "Add-on", "name": "Add-on"}
+
+
+###################################################################
+# These classes represent entities within a Keystone integration. #
+###################################################################
+
 # TODO: Fill in User.outgoing_edges.QuotaSet.MATCHING_FN, Domain, Group, Token,
 # Credential, Role, Region, Endpoint, Service.
 
@@ -631,9 +671,9 @@ class Project(PolyResource):
         return {"integration_name": "Keystone", "name": "Project"}
 
 
-#
-# These classes represent entities within a Nova integration.
-#
+###############################################################
+# These classes represent entities within a Nova integration. #
+###############################################################
 
 class AvailabilityZone(PolyResource):
     """An OpenStack Availability Zone."""
@@ -1243,9 +1283,9 @@ class NovaLimits(PolyResource):
         return {"integration_name": "Nova", "name": "Limits"}
 
 
-#
-# These classes represent entities within a Glance integration.
-#
+#################################################################
+# These classes represent entities within a Glance integration. #
+#################################################################
 
 class Image(PolyResource):
     """An OpenStack Image."""
@@ -1284,9 +1324,9 @@ class Image(PolyResource):
         return {"integration_name": "Glance", "name": "Image"}
 
 
-#
-# These classes represent entities within a Cinder integration.
-#
+#################################################################
+# These classes represent entities within a Cinder integration. #
+#################################################################
 
 class QuotaSet(PolyResource):
     """An OpenStack Quota Set."""
@@ -1505,9 +1545,10 @@ class Limits(PolyResource):
         return {"integration_name": "Cinder", "name": "Limits"}
 
 
-#
-# These classes represent entities within a Neutron integration.
-#
+##################################################################
+# These classes represent entities within a Neutron integration. #
+##################################################################
+
 # TODO: Fill in MeteringLabelRule, MeteringLabel, NeutronQuota, RemoteGroup,
 # SecurityRules, SecurityGroup., LBVIP, LBPool, HealthMonitor, FloatingIP,
 # FloatingIPPool, FixedIP, LBMember, Subnet, Network, Router.

--- a/goldstone/core/resource.py
+++ b/goldstone/core/resource.py
@@ -16,6 +16,9 @@ from datetime import datetime, timedelta
 from django.conf import settings
 import logging
 import networkx
+import sys
+
+from goldstone.addons.models import Addon as AddonTable
 from .models import User, Domain, Group, Token, Credential, Role, Region, \
     Endpoint, Service, Project, AvailabilityZone, Aggregate, \
     Flavor, Keypair, Host, Hypervisor, Cloudpipe, ServerGroup, Server, \
@@ -23,12 +26,12 @@ from .models import User, Domain, Group, Token, Credential, Role, Region, \
     Volume, Limits, MeteringLabelRule, MeteringLabel, NeutronQuota, \
     RemoteGroup, SecurityRules, SecurityGroup, Port, LBVIP, LBPool, \
     HealthMonitor, FloatingIP, FloatingIPPool, FixedIP, LBMember, Subnet, \
-    Network, Router
+    Network, Router, Addon
 
 # These are the types of resources in an OpenStack cloud.
 RESOURCE_TYPES = [User, Domain, Group, Token, Credential, Role, Region,
                   Endpoint, Service, Project, AvailabilityZone,
-                  Aggregate, Flavor, Keypair, Host,
+                  Aggregate, Flavor, Keypair, Host, Addon,
                   Hypervisor, Cloudpipe, ServerGroup, Server, Interface,
                   NovaLimits, Image, QuotaSet, QOSSpec, Snapshot, VolumeType,
                   Volume, Limits, MeteringLabelRule, MeteringLabel,
@@ -40,6 +43,9 @@ RESOURCE_TYPES = [User, Domain, Group, Token, Credential, Role, Region,
 TO = settings.R_ATTRIBUTE.TO
 TYPE = settings.R_ATTRIBUTE.TYPE
 EDGE_ATTRIBUTES = settings.R_ATTRIBUTE.EDGE_ATTRIBUTES
+INSTANCE_OF = settings.R_EDGE.INSTANCE_OF
+MAX = settings.R_ATTRIBUTE.MAX
+MIN = settings.R_ATTRIBUTE.MIN
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +105,17 @@ class Graph(object):
 
 
 class Types(Graph):
-    """A graph of an OpenStack cloud's resource types."""
+    """A graph of an OpenStack cloud's resource types.
+
+    The correct way to import this:
+
+         from goldstone.core import resource
+         foo = resource.types....
+
+    If you use, "from resources import types," it adds instances to the
+    local namespace, and it won't work as you expect.
+
+    """
 
     def __init__(self):
         """Initialize the object.
@@ -108,36 +124,44 @@ class Types(Graph):
                  cloud.
 
         """
+        from importlib import import_module
 
         super(Types, self).__init__()
 
-        # Every resource type has an outgoing_edges() class method.
-        #
-        # Each entry in the value of outgoing_edges() is a control_dict.  Each
-        # control_dict is:
-        #
-        #   TO: The destination type
-        #   EDGE_ATTTRIBUTES: This edge's attributes:
-        #       TYPE: The type of this edge
-        #       MIN: A resource graph node has a minimum number of this edge
-        #            type
-        #       MAX: A resource graph node has a maximum number of this edge
-        #            type
-        #       MATCHING_FN: Callable(from_attr_dict, to_attr_dict).  If
-        #                    there's a match between the from_node's and
-        #                    to_node's attribute dicts, we draw a Resource
-        #                    graph edge. Note: This must be prepared for absent
-        #                    ekeys, and not throw exceptions.
-        #
-        # For every control_dict in every outgoing_edges list of every
-        # resource type...
+        # Add the built-in Goldstone resource types. For every control_dict in
+        # every outgoing_edges() list of every resource type...
         for source_type in RESOURCE_TYPES:
+            self.graph.add_node(source_type)
+
             for control_dict in source_type.outgoing_edges():
                 # (If an edge connects nodes not yet in the graph, the
                 # nodes are automatically added.)
                 self.graph.add_edge(source_type,
                                     control_dict[TO],
                                     attr_dict=control_dict[EDGE_ATTRIBUTES])
+
+        # Now the add-on resource types.
+        for row in AddonTable.objects.all():
+            the_app = import_module("%s.models" % row.name)
+            addon_types = getattr(the_app, "resource_types")
+
+            for source_type in addon_types():
+                if hasattr(source_type, "root"):
+                    # This is the add-on root. Make an edge from the Addon type
+                    # to this type.
+                    self.graph.add_edge(Addon,
+                                        source_type,
+                                        attr_dict={TYPE: INSTANCE_OF,
+                                                   MIN: 0,
+                                                   MAX: sys.maxint})
+
+                for control_dict in source_type.outgoing_edges():
+                    # (If an edge connects nodes not yet in the graph, the
+                    # nodes are automatically added.)
+                    self.graph.add_edge(
+                        source_type,
+                        control_dict[TO],
+                        attr_dict=control_dict[EDGE_ATTRIBUTES])
 
     @classmethod
     def get_type(cls, unique_id):
@@ -156,7 +180,10 @@ class Types(Graph):
 
         return None
 
-# This is Goldstone's resource type graph.
+# This is Goldstone's resource type graph. Since the webserver is restarted
+# after adding or removing an add-on, we don't have to support dynamic add-on
+# insertion. When the webserver is restarted after adding an add-on, the
+# resource type graph will be re-built and the add-on's types will be included.
 types = Types()                      # pylint: disable=C0103
 
 

--- a/goldstone/core/resource.py
+++ b/goldstone/core/resource.py
@@ -150,10 +150,8 @@ class Types(Graph):
                                if PolyResource in getmro(x) and
                                x != PolyResource]
 
-                # Addon_types is the add-on's model classes that are derived
-                # from PolyResource, except for PolyResource itself.
-                # (PolyResource shows up in the class list if it's imported
-                # from another module.)
+                # Addon_types contains the add-on's model classes that are
+                # derived from PolyResource, excluding PolyResource itself.
                 for source_type in addon_types:
                     self.graph.add_node(source_type)
 
@@ -172,7 +170,7 @@ class Types(Graph):
                             source_type,
                             control_dict[TO],
                             attr_dict=control_dict[EDGE_ATTRIBUTES])
-            except Exception:
+            except Exception:         # pylint: disable=W0703
                 logger.exception("Problem adding %s to the resource type "
                                  "graph! Skipping...", row)
                 continue

--- a/goldstone/core/resource.py
+++ b/goldstone/core/resource.py
@@ -26,7 +26,7 @@ from .models import User, Domain, Group, Token, Credential, Role, Region, \
     Volume, Limits, MeteringLabelRule, MeteringLabel, NeutronQuota, \
     RemoteGroup, SecurityRules, SecurityGroup, Port, LBVIP, LBPool, \
     HealthMonitor, FloatingIP, FloatingIPPool, FixedIP, LBMember, Subnet, \
-    Network, Router, Addon
+    Network, Router, Addon, PolyResource
 
 # These are the types of resources in an OpenStack cloud.
 RESOURCE_TYPES = [User, Domain, Group, Token, Credential, Role, Region,
@@ -125,6 +125,7 @@ class Types(Graph):
 
         """
         from importlib import import_module
+        from inspect import getmro
 
         super(Types, self).__init__()
 
@@ -143,7 +144,8 @@ class Types(Graph):
         # Now the add-on resource types.
         for row in AddonTable.objects.all():
             the_app = import_module("%s.models" % row.name)
-            addon_types = getattr(the_app, "resource_types")
+            addon_types = [x for x in dir(the_app)
+                           if PolyResource in getmro(x)]
 
             for source_type in addon_types():
                 if hasattr(source_type, "root"):
@@ -237,7 +239,6 @@ class Instances(Graph):
         the db table.
 
         """
-        from .models import PolyResource
 
         def get_uuid(uuid):
             """Return the graph node having this UUID.

--- a/goldstone/core/tasks.py
+++ b/goldstone/core/tasks.py
@@ -43,23 +43,28 @@ def delete_indices(prefix,
 @celery_app.task()
 def update_persistent_graph():
     """Update the Resource graph's persistent data from the current OpenStack
-    cloud state.
+    cloud state, and add-on state.
 
     Nodes are:
-       - deleted if they are no longer in the OpenStack cloud.
-       - added if they are in the OpenStack cloud, but not in the graph.
-       - updated from the cloud if they are already in the graph.
+       - deleted if they are no longer in the OpenStack cloud, or in the Addon
+         table.
+       - added if they are in the OpenStack cloud or Addon table, but not in
+         the graph.
+       - updated from the cloud or Addon table if they are already in the
+         graph.
 
     """
+    from goldstone.addons.utils import update_addon_nodes
     from goldstone.cinder.utils import update_cinder_nodes
     from goldstone.glance.utils import update_glance_nodes
     from goldstone.keystone.utils import update_keystone_nodes
     from goldstone.nova.utils import update_nova_nodes
 
+    update_addon_nodes()
+    update_cinder_nodes()
     update_glance_nodes()
     update_keystone_nodes()
     update_nova_nodes()
-    update_cinder_nodes()
 
 
 @celery_app.task()

--- a/goldstone/core/test_addons_models/__init__.py
+++ b/goldstone/core/test_addons_models/__init__.py
@@ -1,1 +1,1 @@
-# This subdirectory is for unit testing.
+"""This subdirectory is for unit testing."""

--- a/goldstone/core/test_addons_models/__init__.py
+++ b/goldstone/core/test_addons_models/__init__.py
@@ -1,0 +1,1 @@
+# This subdirectory is for unit testing.

--- a/goldstone/core/test_addons_models/models.py
+++ b/goldstone/core/test_addons_models/models.py
@@ -29,7 +29,6 @@ TYPE = settings.R_ATTRIBUTE.TYPE
 MATCHING_FN = settings.R_ATTRIBUTE.MATCHING_FN
 EDGE_ATTRIBUTES = settings.R_ATTRIBUTE.EDGE_ATTRIBUTES
 
-INSTANCE_OF = settings.R_EDGE.INSTANCE_OF
 OWNS = settings.R_EDGE.OWNS
 
 
@@ -37,6 +36,7 @@ class ButterfingerBar(PolyResource):
     """A Butterfinger."""
 
     pass
+
 
 class SnickersBar(PolyResource):
     """A Snickers."""

--- a/goldstone/core/test_addons_models/models.py
+++ b/goldstone/core/test_addons_models/models.py
@@ -1,0 +1,73 @@
+"""Test models for core unit tests.
+
+All classes derived from goldstone.core.models.PolyResource will be added to
+the Goldstone resource type graph.
+
+"""
+# Copyright 2015 Solinea, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from django.conf import settings
+from goldstone.core.models import PolyResource
+import sys
+
+# Aliases to make the Resource Graph definitions less verbose.
+MAX = settings.R_ATTRIBUTE.MAX
+MIN = settings.R_ATTRIBUTE.MIN
+TO = settings.R_ATTRIBUTE.TO
+TYPE = settings.R_ATTRIBUTE.TYPE
+MATCHING_FN = settings.R_ATTRIBUTE.MATCHING_FN
+EDGE_ATTRIBUTES = settings.R_ATTRIBUTE.EDGE_ATTRIBUTES
+
+INSTANCE_OF = settings.R_EDGE.INSTANCE_OF
+OWNS = settings.R_EDGE.OWNS
+
+
+class ButterfingerBar(PolyResource):
+    """A Butterfinger."""
+
+    pass
+
+class SnickersBar(PolyResource):
+    """A Snickers."""
+
+    @classmethod
+    def outgoing_edges(cls):      # pylint: disable=R0201
+        """Return the edges leaving this type."""
+
+        return [{TO: ButterfingerBar,
+                 MATCHING_FN:
+                 lambda f, t: f.get("name") == t.get("name"),
+                 EDGE_ATTRIBUTES: {TYPE: OWNS,
+                                   MIN: 0,
+                                   MAX: sys.maxint}},
+                ]
+
+
+class FooBar(PolyResource):
+    """The FooBar add-on resource type."""
+
+    # Identify this class as the FooBar root.
+    root = True
+
+    @classmethod
+    def outgoing_edges(cls):      # pylint: disable=R0201
+        """Return the edges leaving this type."""
+
+        return [{TO: SnickersBar,
+                 MATCHING_FN:
+                 lambda f, t: f.get("name") == t.get("name"),
+                 EDGE_ATTRIBUTES: {TYPE: OWNS,
+                                   MIN: 0,
+                                   MAX: sys.maxint}},
+                ]

--- a/goldstone/core/test_addons_nomodels/__init__.py
+++ b/goldstone/core/test_addons_nomodels/__init__.py
@@ -1,1 +1,1 @@
-# This subdirectory is for unit testing.
+"""This subdirectory is for unit testing."""

--- a/goldstone/core/test_addons_nomodels/__init__.py
+++ b/goldstone/core/test_addons_nomodels/__init__.py
@@ -1,0 +1,1 @@
+# This subdirectory is for unit testing.

--- a/goldstone/core/test_addons_nomodels/models.py
+++ b/goldstone/core/test_addons_nomodels/models.py
@@ -1,0 +1,90 @@
+"""A models file without any PolyResource subclasses."""
+# Copyright 2015 Solinea, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from django.conf import settings
+from django.db.models import CharField, IntegerField
+from django_extensions.db.fields import UUIDField, CreationDateTimeField, \
+    ModificationDateTimeField
+from elasticsearch_dsl import String, Date, Integer, A
+from elasticsearch_dsl.query import Q, QueryString
+from goldstone.drfes.models import DailyIndexDocType
+from goldstone.glogging.models import LogData, LogEvent
+from picklefield.fields import PickledObjectField
+
+# Get_glance_client is defined here for easy unit test mocking.
+from goldstone.utils import utc_now, get_glance_client, get_nova_client, \
+    get_cinder_client, get_keystone_client, get_cloud
+
+import sys
+
+# Aliases to make the Resource Graph definitions less verbose.
+MAX = settings.R_ATTRIBUTE.MAX
+MIN = settings.R_ATTRIBUTE.MIN
+TO = settings.R_ATTRIBUTE.TO
+TYPE = settings.R_ATTRIBUTE.TYPE
+MATCHING_FN = settings.R_ATTRIBUTE.MATCHING_FN
+EDGE_ATTRIBUTES = settings.R_ATTRIBUTE.EDGE_ATTRIBUTES
+
+ALLOCATED_TO = settings.R_EDGE.ALLOCATED_TO
+APPLIES_TO = settings.R_EDGE.APPLIES_TO
+ASSIGNED_TO = settings.R_EDGE.ASSIGNED_TO
+ATTACHED_TO = settings.R_EDGE.ATTACHED_TO
+CONSUMES = settings.R_EDGE.CONSUMES
+CONTAINS = settings.R_EDGE.CONTAINS
+DEFINES = settings.R_EDGE.DEFINES
+INSTANCE_OF = settings.R_EDGE.INSTANCE_OF
+MEMBER_OF = settings.R_EDGE.MEMBER_OF
+OWNS = settings.R_EDGE.OWNS
+ROUTES_TO = settings.R_EDGE.ROUTES_TO
+SUBSCRIBED_TO = settings.R_EDGE.SUBSCRIBED_TO
+USES = settings.R_EDGE.USES
+
+
+class MetricData(DailyIndexDocType):
+    """Search interface for an agent generated metric."""
+
+    INDEX_PREFIX = 'goldstone_metrics-'
+
+    class Meta:          # pylint: disable=C0111,W0232,C1001
+        doc_type = 'core_metric'
+
+    @classmethod
+    def stats_agg(cls):
+        return A('extended_stats', field='value')
+
+    @classmethod
+    def units_agg(cls):
+        return A('terms', field='unit')
+
+
+class ReportData(DailyIndexDocType):
+
+    INDEX_PREFIX = 'goldstone_reports-'
+
+    class Meta:          # pylint: disable=C0111,W0232,C1001
+        doc_type = 'core_report'
+
+
+class EventData(DailyIndexDocType):
+    """The model for logstash events data."""
+
+    # The indexes we look for start with this string.
+    INDEX_PREFIX = 'events'
+
+    # Time sorting is on this key in the log.
+    SORT = '-timestamp'
+
+    class Meta:          # pylint: disable=C0111,W0232,C1001
+        # Return all document types.
+        doc_type = ''

--- a/goldstone/core/test_addons_nomodels/models.py
+++ b/goldstone/core/test_addons_nomodels/models.py
@@ -12,43 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from django.conf import settings
-from django.db.models import CharField, IntegerField
-from django_extensions.db.fields import UUIDField, CreationDateTimeField, \
-    ModificationDateTimeField
-from elasticsearch_dsl import String, Date, Integer, A
-from elasticsearch_dsl.query import Q, QueryString
+from elasticsearch_dsl import A
 from goldstone.drfes.models import DailyIndexDocType
-from goldstone.glogging.models import LogData, LogEvent
-from picklefield.fields import PickledObjectField
-
-# Get_glance_client is defined here for easy unit test mocking.
-from goldstone.utils import utc_now, get_glance_client, get_nova_client, \
-    get_cinder_client, get_keystone_client, get_cloud
-
-import sys
-
-# Aliases to make the Resource Graph definitions less verbose.
-MAX = settings.R_ATTRIBUTE.MAX
-MIN = settings.R_ATTRIBUTE.MIN
-TO = settings.R_ATTRIBUTE.TO
-TYPE = settings.R_ATTRIBUTE.TYPE
-MATCHING_FN = settings.R_ATTRIBUTE.MATCHING_FN
-EDGE_ATTRIBUTES = settings.R_ATTRIBUTE.EDGE_ATTRIBUTES
-
-ALLOCATED_TO = settings.R_EDGE.ALLOCATED_TO
-APPLIES_TO = settings.R_EDGE.APPLIES_TO
-ASSIGNED_TO = settings.R_EDGE.ASSIGNED_TO
-ATTACHED_TO = settings.R_EDGE.ATTACHED_TO
-CONSUMES = settings.R_EDGE.CONSUMES
-CONTAINS = settings.R_EDGE.CONTAINS
-DEFINES = settings.R_EDGE.DEFINES
-INSTANCE_OF = settings.R_EDGE.INSTANCE_OF
-MEMBER_OF = settings.R_EDGE.MEMBER_OF
-OWNS = settings.R_EDGE.OWNS
-ROUTES_TO = settings.R_EDGE.ROUTES_TO
-SUBSCRIBED_TO = settings.R_EDGE.SUBSCRIBED_TO
-USES = settings.R_EDGE.USES
 
 
 class MetricData(DailyIndexDocType):
@@ -61,14 +26,17 @@ class MetricData(DailyIndexDocType):
 
     @classmethod
     def stats_agg(cls):
+        """Meaningless."""
         return A('extended_stats', field='value')
 
     @classmethod
     def units_agg(cls):
+        """Meaningless."""
         return A('terms', field='unit')
 
 
 class ReportData(DailyIndexDocType):
+    """Meaningless."""
 
     INDEX_PREFIX = 'goldstone_reports-'
 

--- a/goldstone/core/tests.py
+++ b/goldstone/core/tests.py
@@ -24,7 +24,7 @@ from mock import patch, MagicMock
 from rest_framework.test import APISimpleTestCase
 
 from .models import Image, ServerGroup, NovaLimits, PolyResource, Host, \
-    Aggregate, Hypervisor, Port, Cloudpipe, Network, Project, Server
+    Aggregate, Hypervisor, Port, Cloudpipe, Network, Project, Server, Addon
 
 from . import tasks
 from .utils import custom_exception_handler, process_resource_type, parse
@@ -34,13 +34,13 @@ from .utils import custom_exception_handler, process_resource_type, parse
 # when we need to clear the PolyResource table, we'll individually delete each
 # subclass.
 NODE_TYPES = [Image, ServerGroup, NovaLimits, Host, Aggregate, Cloudpipe, Port,
-              Hypervisor, Project, Network, Server]
+              Hypervisor, Project, Network, Server, Addon]
 
 # Aliases to make the code less verbose
 TYPE = settings.R_ATTRIBUTE.TYPE
 
 
-def _load_persistent_rg(startnodes, startedges):
+def load_persistent_rg(startnodes, startedges):
     """Create PolyResource database rows.
 
     :param startnodes: The nodes to add.
@@ -199,7 +199,7 @@ class UpdateEdges(SimpleTestCase):
         # Test data. Each entry is (Type, native_id).
         NODES = [(Host, "deadbeef")]
 
-        _load_persistent_rg(NODES, [])
+        load_persistent_rg(NODES, [])
 
         # Get the Host instance and do the test.
         node = Host.objects.all()[0]
@@ -227,7 +227,7 @@ class UpdateEdges(SimpleTestCase):
                  (Hypervisor, "1"),
                  (Hypervisor, "2")]
 
-        _load_persistent_rg(NODES, [])
+        load_persistent_rg(NODES, [])
 
         # Set up the host attributes.
         node = Host.objects.all()[0]
@@ -264,7 +264,7 @@ class UpdateEdges(SimpleTestCase):
                  (Hypervisor, "1"),
                  (Hypervisor, "2")]
 
-        _load_persistent_rg(NODES, [])
+        load_persistent_rg(NODES, [])
 
         # Set up the host attributes.
         node = Host.objects.all()[0]
@@ -302,7 +302,7 @@ class UpdateEdges(SimpleTestCase):
                  (Cloudpipe, "deadbeef"),
                  (Port, "deadbeef")]
 
-        _load_persistent_rg(NODES, [])
+        load_persistent_rg(NODES, [])
 
         # Set up the host attributes.
         node = Host.objects.all()[0]
@@ -340,7 +340,7 @@ class UpdateEdges(SimpleTestCase):
                  (Port, "cad"),
                  (Network, "cad")]
 
-        _load_persistent_rg(NODES, [])
+        load_persistent_rg(NODES, [])
 
         # Set up the project attributes.
         node = Project.objects.all()[0]
@@ -441,7 +441,7 @@ class ProcessResourceType(SimpleTestCase):
         EDGES = [((Image, "a"), (Image, "ab")), ((Image, "abc"), (Image, "a"))]
 
         # Create the PolyResource database rows.
-        _load_persistent_rg(NODES, EDGES)
+        load_persistent_rg(NODES, EDGES)
 
         # Set up get_glance_client to return an empty OpenStack cloud.
         ggc.return_value = {"client": self.EmptyClientObject(),
@@ -486,7 +486,7 @@ class ProcessResourceType(SimpleTestCase):
                  ]
 
         # Create the PolyResource database rows.
-        _load_persistent_rg(NODES, EDGES)
+        load_persistent_rg(NODES, EDGES)
 
         # Set up get_glance_client to return an empty OpenStack cloud.
         ggc.return_value = {"client": self.EmptyClientObject(),
@@ -569,7 +569,7 @@ class ProcessResourceType(SimpleTestCase):
                  ]
 
         # Create the PolyResource database rows.
-        _load_persistent_rg(NODES, EDGES)
+        load_persistent_rg(NODES, EDGES)
 
         # Set up get_glance_client to return some glance and other services.
         cloud = self.EmptyClientObject()
@@ -628,7 +628,7 @@ class ProcessResourceType(SimpleTestCase):
                  ]
 
         # Create the PolyResource database rows.
-        _load_persistent_rg(NODES, EDGES)
+        load_persistent_rg(NODES, EDGES)
 
         # Set up get_glance_client to return some glance and other services.
         cloud = self.EmptyClientObject()
@@ -688,7 +688,7 @@ class ProcessResourceType(SimpleTestCase):
                  ]
 
         # Create the PolyResource database rows.
-        _load_persistent_rg(NODES, EDGES)
+        load_persistent_rg(NODES, EDGES)
 
         # Set up get_glance_client to return some glance services, two of
         # which have duplicate OpenStack ids.

--- a/goldstone/core/tests_resource_api_1.py
+++ b/goldstone/core/tests_resource_api_1.py
@@ -231,6 +231,11 @@ class CoreResourceTypes(Setup):
                      u'present': False,
                      u'unique_id':
                      u"<class 'goldstone.core.models.MeteringLabel'>"},
+                    {u'display_attributes': {u'name': u'Metering Label Rule',
+                                             u'integration_name': u'Neutron'},
+                     u'present': False,
+                     u'unique_id':
+                     u"<class 'goldstone.core.models.MeteringLabelRule'>"},
                     {u'display_attributes': {u'name': u'Token',
                                              u'integration_name': u'Keystone'},
                      u'present': False,
@@ -317,6 +322,11 @@ class CoreResourceTypes(Setup):
                      u'present': False,
                      u'unique_id':
                      u"<class 'goldstone.core.models.Interface'>"},
+                    {u'display_attributes': {u'name': u'Add-on',
+                                             u'integration_name': u'Add-on'},
+                     u'present': False,
+                     u'unique_id':
+                     u"<class 'goldstone.core.models.Addon'>"},
                     ]
 
         # Create the nodes for the test.

--- a/goldstone/core/tests_resource_types_2.py
+++ b/goldstone/core/tests_resource_types_2.py
@@ -421,3 +421,405 @@ class ResourceTypesTests(SimpleTestCase):
                 Volume,
                 VOLUME,
                 partial(dictassign, VOLUME, "snapshot_id"))
+
+
+class ResourceAddonTypes(SimpleTestCase):
+    """Test processsing of add-on resource types."""
+
+    @staticmethod
+    def test_server_interface():
+        """Test the Server - Interface entry."""
+
+        # Test data.
+        SERVER = {u'OS-DCF:diskConfig': u'MANUAL',
+                  u'OS-EXT-AZ:availability_zone': u'nova',
+                  u'OS-EXT-SRV-ATTR:host': u'john.oak.solinea.com',
+                  u'OS-EXT-SRV-ATTR:hypervisor_hostname':
+                  u'john.oak.solinea.com',
+                  u'OS-EXT-SRV-ATTR:instance_name': u'instance-00000001',
+                  u'OS-EXT-STS:power_state': 4,
+                  u'OS-EXT-STS:task_state': None,
+                  u'OS-EXT-STS:vm_state': u'stopped',
+                  u'OS-SRV-USG:launched_at': u'2015-01-26T14:01:37.000000',
+                  u'OS-SRV-USG:terminated_at': None,
+                  u'accessIPv4': u'',
+                  u'accessIPv6': u'',
+                  u'addresses':
+                  {u'demo-net':
+                   [{u'OS-EXT-IPS-MAC:mac_addr': u'fa:00:00:7f:2a:00',
+                     u'OS-EXT-IPS:type': u'fixed',
+                     u'addr': u'192.168.1.1',
+                     u'version': 4},
+                    {u'OS-EXT-IPS-MAC:mac_addr': u'fa:00:00:7f:2a:00',
+                     u'OS-EXT-IPS:type': u'floating',
+                     u'addr': u'10.11.12.13',
+                     u'version': 4}]},
+                  u'config_drive': u'',
+                  u'created': u'2015-01-26T14:00:42Z',
+                  u'flavor': {u'id': u'1',
+                              u'links':
+                              [{u'href':
+                                u'http://10.11.12.13:8774/'
+                                u'7077765ed0df43b1b23d43c9c290daf9/flavors/1',
+                                u'rel': u'bookmark'}]},
+                  u'hostId':
+                  u'78f689fe281dbb1deb8e42ac188a9734faf430ddc905b556b74f6144',
+                  u'id': u'ee662ff5-3de6-46cb-8b85-4eb4317beb7c',
+                  u'image': {u'id': u'0ae46ce1-80e5-447e-b0e8-9eeec81af920',
+                             u'links':
+                             [{u'href':
+                               u'http://10.11.12.13:8774/'
+                               u'7077765ed0df43b1b23d43c9c290daf9/'
+                               u'images/0ae46ce1-80e5-447e-b0e8-9eeec81af920',
+                               u'rel': u'bookmark'}]},
+                  u'key_name': None,
+                  u'links':
+                  [{u'href':
+                    u'http://10.10.20.10:8774/v2/7077765ed0df43b1b23d'
+                    u'43c9c290daf9/servers/'
+                    u'ee662ff5-3de6-46cb-8b85-4eb4317beb7c',
+                    u'rel': u'self'},
+                   {u'href':
+                    u'http://10.10.20.10:8774/7077765ed0df43'
+                    u'b1b23d43c9c290daf9/servers/ee662ff5-3de6-46cb-'
+                    u'8b85-4eb4317beb7c',
+                    u'rel': u'bookmark'}],
+                  u'metadata': {},
+                  u'name': u'instance2',
+                  u'os-extended-volumes:volumes_attached': [],
+                  u'security_groups': [{u'name': u'default'}],
+                  u'status': u'SHUTOFF',
+                  u'tenant_id': u'56762288eea24ab08a3b6d06f5a37c14',
+                  u'updated': u'2015-03-04T01:27:22Z',
+                  u'user_id': u'2bb2f66f20cb47e9be48a91941e3353b'}
+
+        INTERFACE = {u'fixed_ips':
+                     [{u'ip_address': u'192.168.1.111',
+                       u'subnet_id': u'623ed5a0-785b-4a8a-94a1-a96dd8679f1c'}],
+                     u'mac_addr': u'fa:16:3e:00:11:22',
+                     u'net_id': u'fa4684fa-7243-45bf-aac5-0a3db0c210b1',
+                     u'port_id': u'f3f6cd1a-b199-4d67-9266-8d69ac1fb46b',
+                     u'port_state': u'ACTIVE'}
+
+        def serverassign(value):
+            """Store value into the server dict's matching attribute."""
+
+            SERVER["addresses"]["demo-net"][0]["OS-EXT-IPS-MAC:mac_addr"] = \
+                value
+
+        do_test(Server,
+                SERVER,
+                serverassign,
+                Interface,
+                INTERFACE,
+                partial(dictassign, INTERFACE, "mac_addr"))
+
+    @staticmethod
+    def test_server_servergroup():
+        """Test the Server - ServerGroup entry."""
+
+        # Test data.
+        SERVER = {u'OS-DCF:diskConfig': u'MANUAL',
+                  u'OS-EXT-AZ:availability_zone': u'nova',
+                  u'OS-EXT-SRV-ATTR:host': u'john.oak.solinea.com',
+                  u'OS-EXT-SRV-ATTR:hypervisor_hostname':
+                  u'john.oak.solinea.com',
+                  u'OS-EXT-SRV-ATTR:instance_name': u'instance-00000001',
+                  u'OS-EXT-STS:power_state': 4,
+                  u'OS-EXT-STS:task_state': None,
+                  u'OS-EXT-STS:vm_state': u'stopped',
+                  u'OS-SRV-USG:launched_at': u'2015-01-26T14:01:37.000000',
+                  u'OS-SRV-USG:terminated_at': None,
+                  u'accessIPv4': u'',
+                  u'accessIPv6': u'',
+                  u'addresses':
+                  {u'demo-net':
+                   [{u'OS-EXT-IPS-MAC:mac_addr': u'fa:00:00:7f:2a:00',
+                     u'OS-EXT-IPS:type': u'fixed',
+                     u'addr': u'192.168.1.1',
+                     u'version': 4},
+                    {u'OS-EXT-IPS-MAC:mac_addr': u'fa:00:00:7f:2a:00',
+                     u'OS-EXT-IPS:type': u'floating',
+                     u'addr': u'10.11.12.13',
+                     u'version': 4}]},
+                  u'config_drive': u'',
+                  u'created': u'2015-01-26T14:00:42Z',
+                  u'flavor': {u'id': u'1',
+                              u'links':
+                              [{u'href':
+                                u'http://10.11.12.13:8774/'
+                                u'7077765ed0df43b1b23d43c9c290daf9/flavors/1',
+                                u'rel': u'bookmark'}]},
+                  u'hostId':
+                  u'78f689fe281dbb1deb8e42ac188a9734faf430ddc905b556b74f6144',
+                  u'id': u'ee662ff5-3de6-46cb-8b85-4eb4317beb7c',
+                  u'image': {u'id': u'0ae46ce1-80e5-447e-b0e8-9eeec81af920',
+                             u'links':
+                             [{u'href':
+                               u'http://10.11.12.13:8774/'
+                               u'7077765ed0df43b1b23d43c9c290daf9/'
+                               u'images/0ae46ce1-80e5-447e-b0e8-9eeec81af920',
+                               u'rel': u'bookmark'}]},
+                  u'key_name': None,
+                  u'links':
+                  [{u'href':
+                    u'http://10.10.20.10:8774/v2/7077765ed0df43b1b23d'
+                    u'43c9c290daf9/servers/'
+                    u'ee662ff5-3de6-46cb-8b85-4eb4317beb7c',
+                    u'rel': u'self'},
+                   {u'href':
+                    u'http://10.10.20.10:8774/7077765ed0df43'
+                    u'b1b23d43c9c290daf9/servers/ee662ff5-3de6-46cb-'
+                    u'8b85-4eb4317beb7c',
+                    u'rel': u'bookmark'}],
+                  u'metadata': {},
+                  u'name': u'instance2',
+                  u'os-extended-volumes:volumes_attached': [],
+                  u'security_groups': [{u'name': u'default'}],
+                  u'status': u'SHUTOFF',
+                  u'tenant_id': u'56762288eea24ab08a3b6d06f5a37c14',
+                  u'updated': u'2015-03-04T01:27:22Z',
+                  u'user_id': u'2bb2f66f20cb47e9be48a91941e3353b'}
+
+        SERVERGROUP = {u'id': u'ef50ce1c-01a9-4b41-a1cb-3a60c84ae1dd',
+                       u'members': [],
+                       u'metadata': {},
+                       u'name': u'derosa',
+                       u'policies': [u'affinity']}
+
+        def servergroupassign(value):
+            """Store value into the servergroup dict's matching attribute."""
+
+            SERVERGROUP["members"].append(value)
+
+        do_test(Server,
+                SERVER,
+                partial(dictassign, SERVER, "hostId"),
+                ServerGroup,
+                SERVERGROUP,
+                servergroupassign)
+
+    @staticmethod
+    def test_server_volume():
+        """Test the Server - Volume entry."""
+
+        # Test data.
+        SERVER = {u'OS-DCF:diskConfig': u'MANUAL',
+                  u'OS-EXT-AZ:availability_zone': u'nova',
+                  u'OS-EXT-SRV-ATTR:host': u'john.oak.solinea.com',
+                  u'OS-EXT-SRV-ATTR:hypervisor_hostname':
+                  u'john.oak.solinea.com',
+                  u'OS-EXT-SRV-ATTR:instance_name': u'instance-00000001',
+                  u'OS-EXT-STS:power_state': 4,
+                  u'OS-EXT-STS:task_state': None,
+                  u'OS-EXT-STS:vm_state': u'stopped',
+                  u'OS-SRV-USG:launched_at': u'2015-01-26T14:01:37.000000',
+                  u'OS-SRV-USG:terminated_at': None,
+                  u'accessIPv4': u'',
+                  u'accessIPv6': u'',
+                  u'addresses':
+                  {u'demo-net':
+                   [{u'OS-EXT-IPS-MAC:mac_addr': u'fa:00:00:7f:2a:00',
+                     u'OS-EXT-IPS:type': u'fixed',
+                     u'addr': u'192.168.1.1',
+                     u'version': 4},
+                    {u'OS-EXT-IPS-MAC:mac_addr': u'fa:00:00:7f:2a:00',
+                     u'OS-EXT-IPS:type': u'floating',
+                     u'addr': u'10.11.12.13',
+                     u'version': 4}]},
+                  u'config_drive': u'',
+                  u'created': u'2015-01-26T14:00:42Z',
+                  u'flavor': {u'id': u'1',
+                              u'links':
+                              [{u'href':
+                                u'http://10.11.12.13:8774/'
+                                u'7077765ed0df43b1b23d43c9c290daf9/flavors/1',
+                                u'rel': u'bookmark'}]},
+                  u'hostId':
+                  u'78f689fe281dbb1deb8e42ac188a9734faf430ddc905b556b74f6144',
+                  u'id': u'ee662ff5-3de6-46cb-8b85-4eb4317beb7c',
+                  u'image': {u'id': u'0ae46ce1-80e5-447e-b0e8-9eeec81af920',
+                             u'links':
+                             [{u'href':
+                               u'http://10.11.12.13:8774/'
+                               u'7077765ed0df43b1b23d43c9c290daf9/'
+                               u'images/0ae46ce1-80e5-447e-b0e8-9eeec81af920',
+                               u'rel': u'bookmark'}]},
+                  u'key_name': None,
+                  u'links':
+                  [{u'href':
+                    u'http://10.10.20.10:8774/v2/7077765ed0df43b1b23d'
+                    u'43c9c290daf9/servers/'
+                    u'ee662ff5-3de6-46cb-8b85-4eb4317beb7c',
+                    u'rel': u'self'},
+                   {u'href':
+                    u'http://10.10.20.10:8774/7077765ed0df43'
+                    u'b1b23d43c9c290daf9/servers/ee662ff5-3de6-46cb-'
+                    u'8b85-4eb4317beb7c',
+                    u'rel': u'bookmark'}],
+                  u'metadata': {},
+                  u'name': u'instance2',
+                  u'os-extended-volumes:volumes_attached': [],
+                  u'security_groups': [{u'name': u'default'}],
+                  u'status': u'SHUTOFF',
+                  u'tenant_id': u'56762288eea24ab08a3b6d06f5a37c14',
+                  u'updated': u'2015-03-04T01:27:22Z',
+                  u'user_id': u'2bb2f66f20cb47e9be48a91941e3353b'}
+
+        VOLUME = {"id": "45baf976-c20a-4894-a7c3-c94b7376bf55",
+                  "links": [
+                      {"href":
+                       "http://localhost:8776/v2/foobar/volumes/45baf976-c20a"
+                       "-4894-a7c3-c94b7376bf55",
+                       "rel": "self"},
+                      {"href":
+                       "http://localhost:8776/zippy/volumes/45baf976-c20a-489"
+                       "4-a7c3-c94b7376bf55",
+                       "rel": "bookmark"}
+                  ],
+                  "name": "vol-004",
+                  }
+
+        def serverassign(value):
+            """Store value into the server dict's matching attribute."""
+
+            SERVER["links"][1]["href"] = value
+
+        def volumeassign(value):
+            """Store value into the volume dict's matching attribute."""
+
+            VOLUME["links"][0]["href"] = value
+
+        do_test(Server,
+                SERVER,
+                serverassign,
+                Volume,
+                VOLUME,
+                volumeassign)
+
+    @staticmethod
+    def test_qosspec_volumetype():
+        """Test the QOS Spec - Volume Type entry."""
+
+        # Test data.
+        QOSSPEC = {"specs": {"availability": "100",
+                             "numberOfFailures": "0"
+                             },
+                   "consumer": "back-end",
+                   "name": "reliability-spec",
+                   "id": "0388d6c6-d5d4-42a3-b289-95205c50dd15"
+                   }
+
+        VOLUME_TYPE = {"extra_specs": {"capabilities": "gpu"},
+                       "id": "6685584b-1eac-4da6-b5c3-555430cf68ff",
+                       "name": "SSD"
+                       }
+
+        def volumetypeassign(value):
+            """Store value into the volume type dict's matching attribute."""
+
+            VOLUME_TYPE["extra_specs"]["qos"] = value
+
+        do_test(QOSSpec,
+                QOSSPEC,
+                partial(dictassign, QOSSPEC, "id"),
+                VolumeType,
+                VOLUME_TYPE,
+                volumetypeassign)
+
+    @staticmethod
+    def test_volumetype_volume():
+        """Test the Volume Type - Volume entry."""
+
+        # Test data.
+        VOLUME_TYPE = {"extra_specs": {"capabilities": "gpu"},
+                       "id": "6685584b-1eac-4da6-b5c3-555430cf68ff",
+                       "name": "SSD"
+                       }
+
+        VOLUME = {"status": "available",
+                  "attachments": [],
+                  "links": [
+                      {"href":
+                       "http://localhost:8776/v2/de/volumes/5aa119a8-d25b-"
+                       "45a7-8d1b-88e127885635",
+                       "rel": "self"},
+                      {"href":
+                       "http://localhost:8776/0c2ebae/volumes/5aa119a8-d25b-"
+                       "45a7-8d1b-88e127885635",
+                       "rel": "bookmark"}
+                  ],
+                  "availability_zone": "nova",
+                  "bootable": "false",
+                  "os-vol-host-attr:host": "ip-10-168-107-25",
+                  "source_volid": None,
+                  "snapshot_id": None,
+                  "id": "5aa119a8-d25b-45a7-8d1b-88e127885635",
+                  "description": "Super volume.",
+                  "name": "vol-002",
+                  "created_at": "2013-02-25T02:40:21.000000",
+                  "volume_type": "None",
+                  "os-vol-tenant-attr:tenant_id":
+                  "0c2eba2c5af04d3f9e9d0d410b371fde",
+                  "size": 1,
+                  "metadata": {"contents": "not junk"}
+                  }
+
+        do_test(VolumeType,
+                VOLUME_TYPE,
+                partial(dictassign, VOLUME_TYPE, "id"),
+                Volume,
+                VOLUME,
+                partial(dictassign, VOLUME, "volume_type"))
+
+    @staticmethod
+    def test_snapshot_volume():
+        """Test the Snapshot - Volume entry."""
+
+        # Test data.
+        SNAPSHOT = {"status": "available",
+                    "os-extended-snapshot-attributes:progress": "100%",
+                    "description": "Daily backup",
+                    "created_at": "2013-02-25T07:30:12.000000",
+                    "metadata": {},
+                    "volume_id": "5aa119a8-d25b-45a7-8d1b-88e127885635",
+                    "os-extended-snapshot-attributes:project_id":
+                    "0c2eba2c5af04d3f9e9d0d410b371fde",
+                    "size": 30,
+                    "id": "43f20e0e-2c2c-4770-9d4e-c3d769ae5470",
+                    "name": "snap-001"}
+
+        VOLUME = {"status": "available",
+                  "attachments": [],
+                  "links": [
+                      {"href":
+                       "http://localhost:8776/v2/de/volumes/5aa119a8-d25b-"
+                       "45a7-8d1b-88e127885635",
+                       "rel": "self"},
+                      {"href":
+                       "http://localhost:8776/0c2ebae/volumes/5aa119a8-d25b-"
+                       "45a7-8d1b-88e127885635",
+                       "rel": "bookmark"}
+                  ],
+                  "availability_zone": "nova",
+                  "bootable": "false",
+                  "os-vol-host-attr:host": "ip-10-168-107-25",
+                  "source_volid": None,
+                  "snapshot_id": None,
+                  "id": "5aa119a8-d25b-45a7-8d1b-88e127885635",
+                  "description": "Super volume.",
+                  "name": "vol-002",
+                  "created_at": "2013-02-25T02:40:21.000000",
+                  "volume_type": "None",
+                  "os-vol-tenant-attr:tenant_id":
+                  "0c2eba2c5af04d3f9e9d0d410b371fde",
+                  "size": 1,
+                  "metadata": {"contents": "not junk"}
+                  }
+
+        do_test(Snapshot,
+                SNAPSHOT,
+                partial(dictassign, SNAPSHOT, "id"),
+                Volume,
+                VOLUME,
+                partial(dictassign, VOLUME, "snapshot_id"))

--- a/goldstone/core/tests_resource_types_2.py
+++ b/goldstone/core/tests_resource_types_2.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from django.test import SimpleTestCase
 from functools import partial
 from mock import patch
 
@@ -445,7 +444,7 @@ class ResourceAddonTypes(Setup):
         for entry in DATA:
             AddonTable.objects.create(**entry)
 
-        # Do the test 
+        # Do the test
         with patch('goldstone.core.resource.logger') as handler:
             types = Types()
             # Logger.exception, not logger, was called, so we can't use the
@@ -469,7 +468,7 @@ class ResourceAddonTypes(Setup):
         for entry in DATA:
             AddonTable.objects.create(**entry)
 
-        # Do the test 
+        # Do the test
         with patch('goldstone.core.resource.logger') as handler:
             types = Types()
             # Logger.exception, not logger, was called, so we can't use the

--- a/goldstone/core/tests_resource_types_2.py
+++ b/goldstone/core/tests_resource_types_2.py
@@ -14,13 +14,17 @@
 # limitations under the License.
 from django.test import SimpleTestCase
 from functools import partial
+from mock import patch
 
 from .models import ServerGroup, Server, Interface, Volume, QOSSpec, \
     VolumeType, Snapshot
+from .resource import Types, RESOURCE_TYPES
 from .tests_resource_types_1 import do_test, dictassign
+from goldstone.addons.models import Addon as AddonTable
+from goldstone.test_utils import Setup
 
 
-class ResourceTypesTests(SimpleTestCase):
+class ResourceTypesTests(Setup):
     """Test each entry in Types.EDGES, in particular the matching_fn
     functions."""
 
@@ -423,403 +427,55 @@ class ResourceTypesTests(SimpleTestCase):
                 partial(dictassign, VOLUME, "snapshot_id"))
 
 
-class ResourceAddonTypes(SimpleTestCase):
+class ResourceAddonTypes(Setup):
     """Test processsing of add-on resource types."""
 
-    @staticmethod
-    def test_server_interface():
-        """Test the Server - Interface entry."""
+    def test_no_types(self):
+        """No types to add."""
 
-        # Test data.
-        SERVER = {u'OS-DCF:diskConfig': u'MANUAL',
-                  u'OS-EXT-AZ:availability_zone': u'nova',
-                  u'OS-EXT-SRV-ATTR:host': u'john.oak.solinea.com',
-                  u'OS-EXT-SRV-ATTR:hypervisor_hostname':
-                  u'john.oak.solinea.com',
-                  u'OS-EXT-SRV-ATTR:instance_name': u'instance-00000001',
-                  u'OS-EXT-STS:power_state': 4,
-                  u'OS-EXT-STS:task_state': None,
-                  u'OS-EXT-STS:vm_state': u'stopped',
-                  u'OS-SRV-USG:launched_at': u'2015-01-26T14:01:37.000000',
-                  u'OS-SRV-USG:terminated_at': None,
-                  u'accessIPv4': u'',
-                  u'accessIPv6': u'',
-                  u'addresses':
-                  {u'demo-net':
-                   [{u'OS-EXT-IPS-MAC:mac_addr': u'fa:00:00:7f:2a:00',
-                     u'OS-EXT-IPS:type': u'fixed',
-                     u'addr': u'192.168.1.1',
-                     u'version': 4},
-                    {u'OS-EXT-IPS-MAC:mac_addr': u'fa:00:00:7f:2a:00',
-                     u'OS-EXT-IPS:type': u'floating',
-                     u'addr': u'10.11.12.13',
-                     u'version': 4}]},
-                  u'config_drive': u'',
-                  u'created': u'2015-01-26T14:00:42Z',
-                  u'flavor': {u'id': u'1',
-                              u'links':
-                              [{u'href':
-                                u'http://10.11.12.13:8774/'
-                                u'7077765ed0df43b1b23d43c9c290daf9/flavors/1',
-                                u'rel': u'bookmark'}]},
-                  u'hostId':
-                  u'78f689fe281dbb1deb8e42ac188a9734faf430ddc905b556b74f6144',
-                  u'id': u'ee662ff5-3de6-46cb-8b85-4eb4317beb7c',
-                  u'image': {u'id': u'0ae46ce1-80e5-447e-b0e8-9eeec81af920',
-                             u'links':
-                             [{u'href':
-                               u'http://10.11.12.13:8774/'
-                               u'7077765ed0df43b1b23d43c9c290daf9/'
-                               u'images/0ae46ce1-80e5-447e-b0e8-9eeec81af920',
-                               u'rel': u'bookmark'}]},
-                  u'key_name': None,
-                  u'links':
-                  [{u'href':
-                    u'http://10.10.20.10:8774/v2/7077765ed0df43b1b23d'
-                    u'43c9c290daf9/servers/'
-                    u'ee662ff5-3de6-46cb-8b85-4eb4317beb7c',
-                    u'rel': u'self'},
-                   {u'href':
-                    u'http://10.10.20.10:8774/7077765ed0df43'
-                    u'b1b23d43c9c290daf9/servers/ee662ff5-3de6-46cb-'
-                    u'8b85-4eb4317beb7c',
-                    u'rel': u'bookmark'}],
-                  u'metadata': {},
-                  u'name': u'instance2',
-                  u'os-extended-volumes:volumes_attached': [],
-                  u'security_groups': [{u'name': u'default'}],
-                  u'status': u'SHUTOFF',
-                  u'tenant_id': u'56762288eea24ab08a3b6d06f5a37c14',
-                  u'updated': u'2015-03-04T01:27:22Z',
-                  u'user_id': u'2bb2f66f20cb47e9be48a91941e3353b'}
+        # Test data. The add-on name will fake out import_module so that it
+        # imports the desired test models file.
+        DATA = [{"name": "goldstone.core.test_addons_nomodels",
+                 "version": "42",
+                 "manufacturer": "Lynbrook Senior High School",
+                 "url_root": "lynbrook"},
+                ]
 
-        INTERFACE = {u'fixed_ips':
-                     [{u'ip_address': u'192.168.1.111',
-                       u'subnet_id': u'623ed5a0-785b-4a8a-94a1-a96dd8679f1c'}],
-                     u'mac_addr': u'fa:16:3e:00:11:22',
-                     u'net_id': u'fa4684fa-7243-45bf-aac5-0a3db0c210b1',
-                     u'port_id': u'f3f6cd1a-b199-4d67-9266-8d69ac1fb46b',
-                     u'port_state': u'ACTIVE'}
+        # Load up the Addon table.
+        for entry in DATA:
+            AddonTable.objects.create(**entry)
 
-        def serverassign(value):
-            """Store value into the server dict's matching attribute."""
+        # Do the test 
+        with patch('goldstone.core.resource.logger') as handler:
+            types = Types()
+            # Logger.exception, not logger, was called, so we can't use the
+            # called attribute!
+            self.assertEqual(handler.mock_calls, [])
 
-            SERVER["addresses"]["demo-net"][0]["OS-EXT-IPS-MAC:mac_addr"] = \
-                value
+        self.assertEqual(len(types.graph.nodes()), len(RESOURCE_TYPES))
 
-        do_test(Server,
-                SERVER,
-                serverassign,
-                Interface,
-                INTERFACE,
-                partial(dictassign, INTERFACE, "mac_addr"))
+    def test_types(self):
+        """Types to add, one root and two others."""
 
-    @staticmethod
-    def test_server_servergroup():
-        """Test the Server - ServerGroup entry."""
+        # Test data. The add-on name will fake out import_module so that it
+        # imports the desired test models file.
+        DATA = [{"name": "goldstone.core.test_addons_models",
+                 "version": "42",
+                 "manufacturer": "Lynbrook Senior High School",
+                 "url_root": "lynbrook"},
+                ]
 
-        # Test data.
-        SERVER = {u'OS-DCF:diskConfig': u'MANUAL',
-                  u'OS-EXT-AZ:availability_zone': u'nova',
-                  u'OS-EXT-SRV-ATTR:host': u'john.oak.solinea.com',
-                  u'OS-EXT-SRV-ATTR:hypervisor_hostname':
-                  u'john.oak.solinea.com',
-                  u'OS-EXT-SRV-ATTR:instance_name': u'instance-00000001',
-                  u'OS-EXT-STS:power_state': 4,
-                  u'OS-EXT-STS:task_state': None,
-                  u'OS-EXT-STS:vm_state': u'stopped',
-                  u'OS-SRV-USG:launched_at': u'2015-01-26T14:01:37.000000',
-                  u'OS-SRV-USG:terminated_at': None,
-                  u'accessIPv4': u'',
-                  u'accessIPv6': u'',
-                  u'addresses':
-                  {u'demo-net':
-                   [{u'OS-EXT-IPS-MAC:mac_addr': u'fa:00:00:7f:2a:00',
-                     u'OS-EXT-IPS:type': u'fixed',
-                     u'addr': u'192.168.1.1',
-                     u'version': 4},
-                    {u'OS-EXT-IPS-MAC:mac_addr': u'fa:00:00:7f:2a:00',
-                     u'OS-EXT-IPS:type': u'floating',
-                     u'addr': u'10.11.12.13',
-                     u'version': 4}]},
-                  u'config_drive': u'',
-                  u'created': u'2015-01-26T14:00:42Z',
-                  u'flavor': {u'id': u'1',
-                              u'links':
-                              [{u'href':
-                                u'http://10.11.12.13:8774/'
-                                u'7077765ed0df43b1b23d43c9c290daf9/flavors/1',
-                                u'rel': u'bookmark'}]},
-                  u'hostId':
-                  u'78f689fe281dbb1deb8e42ac188a9734faf430ddc905b556b74f6144',
-                  u'id': u'ee662ff5-3de6-46cb-8b85-4eb4317beb7c',
-                  u'image': {u'id': u'0ae46ce1-80e5-447e-b0e8-9eeec81af920',
-                             u'links':
-                             [{u'href':
-                               u'http://10.11.12.13:8774/'
-                               u'7077765ed0df43b1b23d43c9c290daf9/'
-                               u'images/0ae46ce1-80e5-447e-b0e8-9eeec81af920',
-                               u'rel': u'bookmark'}]},
-                  u'key_name': None,
-                  u'links':
-                  [{u'href':
-                    u'http://10.10.20.10:8774/v2/7077765ed0df43b1b23d'
-                    u'43c9c290daf9/servers/'
-                    u'ee662ff5-3de6-46cb-8b85-4eb4317beb7c',
-                    u'rel': u'self'},
-                   {u'href':
-                    u'http://10.10.20.10:8774/7077765ed0df43'
-                    u'b1b23d43c9c290daf9/servers/ee662ff5-3de6-46cb-'
-                    u'8b85-4eb4317beb7c',
-                    u'rel': u'bookmark'}],
-                  u'metadata': {},
-                  u'name': u'instance2',
-                  u'os-extended-volumes:volumes_attached': [],
-                  u'security_groups': [{u'name': u'default'}],
-                  u'status': u'SHUTOFF',
-                  u'tenant_id': u'56762288eea24ab08a3b6d06f5a37c14',
-                  u'updated': u'2015-03-04T01:27:22Z',
-                  u'user_id': u'2bb2f66f20cb47e9be48a91941e3353b'}
+        # Load up the Addon table.
+        for entry in DATA:
+            AddonTable.objects.create(**entry)
 
-        SERVERGROUP = {u'id': u'ef50ce1c-01a9-4b41-a1cb-3a60c84ae1dd',
-                       u'members': [],
-                       u'metadata': {},
-                       u'name': u'derosa',
-                       u'policies': [u'affinity']}
+        # Do the test 
+        with patch('goldstone.core.resource.logger') as handler:
+            types = Types()
+            # Logger.exception, not logger, was called, so we can't use the
+            # called attribute!
+            self.assertEqual(handler.mock_calls, [])
 
-        def servergroupassign(value):
-            """Store value into the servergroup dict's matching attribute."""
-
-            SERVERGROUP["members"].append(value)
-
-        do_test(Server,
-                SERVER,
-                partial(dictassign, SERVER, "hostId"),
-                ServerGroup,
-                SERVERGROUP,
-                servergroupassign)
-
-    @staticmethod
-    def test_server_volume():
-        """Test the Server - Volume entry."""
-
-        # Test data.
-        SERVER = {u'OS-DCF:diskConfig': u'MANUAL',
-                  u'OS-EXT-AZ:availability_zone': u'nova',
-                  u'OS-EXT-SRV-ATTR:host': u'john.oak.solinea.com',
-                  u'OS-EXT-SRV-ATTR:hypervisor_hostname':
-                  u'john.oak.solinea.com',
-                  u'OS-EXT-SRV-ATTR:instance_name': u'instance-00000001',
-                  u'OS-EXT-STS:power_state': 4,
-                  u'OS-EXT-STS:task_state': None,
-                  u'OS-EXT-STS:vm_state': u'stopped',
-                  u'OS-SRV-USG:launched_at': u'2015-01-26T14:01:37.000000',
-                  u'OS-SRV-USG:terminated_at': None,
-                  u'accessIPv4': u'',
-                  u'accessIPv6': u'',
-                  u'addresses':
-                  {u'demo-net':
-                   [{u'OS-EXT-IPS-MAC:mac_addr': u'fa:00:00:7f:2a:00',
-                     u'OS-EXT-IPS:type': u'fixed',
-                     u'addr': u'192.168.1.1',
-                     u'version': 4},
-                    {u'OS-EXT-IPS-MAC:mac_addr': u'fa:00:00:7f:2a:00',
-                     u'OS-EXT-IPS:type': u'floating',
-                     u'addr': u'10.11.12.13',
-                     u'version': 4}]},
-                  u'config_drive': u'',
-                  u'created': u'2015-01-26T14:00:42Z',
-                  u'flavor': {u'id': u'1',
-                              u'links':
-                              [{u'href':
-                                u'http://10.11.12.13:8774/'
-                                u'7077765ed0df43b1b23d43c9c290daf9/flavors/1',
-                                u'rel': u'bookmark'}]},
-                  u'hostId':
-                  u'78f689fe281dbb1deb8e42ac188a9734faf430ddc905b556b74f6144',
-                  u'id': u'ee662ff5-3de6-46cb-8b85-4eb4317beb7c',
-                  u'image': {u'id': u'0ae46ce1-80e5-447e-b0e8-9eeec81af920',
-                             u'links':
-                             [{u'href':
-                               u'http://10.11.12.13:8774/'
-                               u'7077765ed0df43b1b23d43c9c290daf9/'
-                               u'images/0ae46ce1-80e5-447e-b0e8-9eeec81af920',
-                               u'rel': u'bookmark'}]},
-                  u'key_name': None,
-                  u'links':
-                  [{u'href':
-                    u'http://10.10.20.10:8774/v2/7077765ed0df43b1b23d'
-                    u'43c9c290daf9/servers/'
-                    u'ee662ff5-3de6-46cb-8b85-4eb4317beb7c',
-                    u'rel': u'self'},
-                   {u'href':
-                    u'http://10.10.20.10:8774/7077765ed0df43'
-                    u'b1b23d43c9c290daf9/servers/ee662ff5-3de6-46cb-'
-                    u'8b85-4eb4317beb7c',
-                    u'rel': u'bookmark'}],
-                  u'metadata': {},
-                  u'name': u'instance2',
-                  u'os-extended-volumes:volumes_attached': [],
-                  u'security_groups': [{u'name': u'default'}],
-                  u'status': u'SHUTOFF',
-                  u'tenant_id': u'56762288eea24ab08a3b6d06f5a37c14',
-                  u'updated': u'2015-03-04T01:27:22Z',
-                  u'user_id': u'2bb2f66f20cb47e9be48a91941e3353b'}
-
-        VOLUME = {"id": "45baf976-c20a-4894-a7c3-c94b7376bf55",
-                  "links": [
-                      {"href":
-                       "http://localhost:8776/v2/foobar/volumes/45baf976-c20a"
-                       "-4894-a7c3-c94b7376bf55",
-                       "rel": "self"},
-                      {"href":
-                       "http://localhost:8776/zippy/volumes/45baf976-c20a-489"
-                       "4-a7c3-c94b7376bf55",
-                       "rel": "bookmark"}
-                  ],
-                  "name": "vol-004",
-                  }
-
-        def serverassign(value):
-            """Store value into the server dict's matching attribute."""
-
-            SERVER["links"][1]["href"] = value
-
-        def volumeassign(value):
-            """Store value into the volume dict's matching attribute."""
-
-            VOLUME["links"][0]["href"] = value
-
-        do_test(Server,
-                SERVER,
-                serverassign,
-                Volume,
-                VOLUME,
-                volumeassign)
-
-    @staticmethod
-    def test_qosspec_volumetype():
-        """Test the QOS Spec - Volume Type entry."""
-
-        # Test data.
-        QOSSPEC = {"specs": {"availability": "100",
-                             "numberOfFailures": "0"
-                             },
-                   "consumer": "back-end",
-                   "name": "reliability-spec",
-                   "id": "0388d6c6-d5d4-42a3-b289-95205c50dd15"
-                   }
-
-        VOLUME_TYPE = {"extra_specs": {"capabilities": "gpu"},
-                       "id": "6685584b-1eac-4da6-b5c3-555430cf68ff",
-                       "name": "SSD"
-                       }
-
-        def volumetypeassign(value):
-            """Store value into the volume type dict's matching attribute."""
-
-            VOLUME_TYPE["extra_specs"]["qos"] = value
-
-        do_test(QOSSpec,
-                QOSSPEC,
-                partial(dictassign, QOSSPEC, "id"),
-                VolumeType,
-                VOLUME_TYPE,
-                volumetypeassign)
-
-    @staticmethod
-    def test_volumetype_volume():
-        """Test the Volume Type - Volume entry."""
-
-        # Test data.
-        VOLUME_TYPE = {"extra_specs": {"capabilities": "gpu"},
-                       "id": "6685584b-1eac-4da6-b5c3-555430cf68ff",
-                       "name": "SSD"
-                       }
-
-        VOLUME = {"status": "available",
-                  "attachments": [],
-                  "links": [
-                      {"href":
-                       "http://localhost:8776/v2/de/volumes/5aa119a8-d25b-"
-                       "45a7-8d1b-88e127885635",
-                       "rel": "self"},
-                      {"href":
-                       "http://localhost:8776/0c2ebae/volumes/5aa119a8-d25b-"
-                       "45a7-8d1b-88e127885635",
-                       "rel": "bookmark"}
-                  ],
-                  "availability_zone": "nova",
-                  "bootable": "false",
-                  "os-vol-host-attr:host": "ip-10-168-107-25",
-                  "source_volid": None,
-                  "snapshot_id": None,
-                  "id": "5aa119a8-d25b-45a7-8d1b-88e127885635",
-                  "description": "Super volume.",
-                  "name": "vol-002",
-                  "created_at": "2013-02-25T02:40:21.000000",
-                  "volume_type": "None",
-                  "os-vol-tenant-attr:tenant_id":
-                  "0c2eba2c5af04d3f9e9d0d410b371fde",
-                  "size": 1,
-                  "metadata": {"contents": "not junk"}
-                  }
-
-        do_test(VolumeType,
-                VOLUME_TYPE,
-                partial(dictassign, VOLUME_TYPE, "id"),
-                Volume,
-                VOLUME,
-                partial(dictassign, VOLUME, "volume_type"))
-
-    @staticmethod
-    def test_snapshot_volume():
-        """Test the Snapshot - Volume entry."""
-
-        # Test data.
-        SNAPSHOT = {"status": "available",
-                    "os-extended-snapshot-attributes:progress": "100%",
-                    "description": "Daily backup",
-                    "created_at": "2013-02-25T07:30:12.000000",
-                    "metadata": {},
-                    "volume_id": "5aa119a8-d25b-45a7-8d1b-88e127885635",
-                    "os-extended-snapshot-attributes:project_id":
-                    "0c2eba2c5af04d3f9e9d0d410b371fde",
-                    "size": 30,
-                    "id": "43f20e0e-2c2c-4770-9d4e-c3d769ae5470",
-                    "name": "snap-001"}
-
-        VOLUME = {"status": "available",
-                  "attachments": [],
-                  "links": [
-                      {"href":
-                       "http://localhost:8776/v2/de/volumes/5aa119a8-d25b-"
-                       "45a7-8d1b-88e127885635",
-                       "rel": "self"},
-                      {"href":
-                       "http://localhost:8776/0c2ebae/volumes/5aa119a8-d25b-"
-                       "45a7-8d1b-88e127885635",
-                       "rel": "bookmark"}
-                  ],
-                  "availability_zone": "nova",
-                  "bootable": "false",
-                  "os-vol-host-attr:host": "ip-10-168-107-25",
-                  "source_volid": None,
-                  "snapshot_id": None,
-                  "id": "5aa119a8-d25b-45a7-8d1b-88e127885635",
-                  "description": "Super volume.",
-                  "name": "vol-002",
-                  "created_at": "2013-02-25T02:40:21.000000",
-                  "volume_type": "None",
-                  "os-vol-tenant-attr:tenant_id":
-                  "0c2eba2c5af04d3f9e9d0d410b371fde",
-                  "size": 1,
-                  "metadata": {"contents": "not junk"}
-                  }
-
-        do_test(Snapshot,
-                SNAPSHOT,
-                partial(dictassign, SNAPSHOT, "id"),
-                Volume,
-                VOLUME,
-                partial(dictassign, VOLUME, "snapshot_id"))
+        # The "+3" is the number of PolyResource-derived classes in the test's
+        # models.py.
+        self.assertEqual(len(types.graph.nodes()), len(RESOURCE_TYPES) + 3)

--- a/goldstone/core/views.py
+++ b/goldstone/core/views.py
@@ -35,7 +35,7 @@ from .utils import parse, query_filter_map
 TYPE = settings.R_ATTRIBUTE.TYPE
 
 
-# Our API documentation extracts this docstring, hence the use of markup.
+# Our API documentation extracts this docstring.
 class ReportDataListView(ElasticListAPIView):
     """Return events from Logstash data.
 
@@ -62,7 +62,7 @@ class ReportDataListView(ElasticListAPIView):
         model = ReportData
 
 
-# Our API documentation extracts this docstring, hence the use of markup.
+# Our API documentation extracts this docstring.
 class ReportNamesAggView(SimpleAggView):
     """Return report name aggregations.
 
@@ -100,7 +100,7 @@ class ReportNamesAggView(SimpleAggView):
         return queryset.query(~Q(Prefix(name='os.service')))
 
 
-# Our API documentation extracts this docstring, hence the use of markup.
+# Our API documentation extracts this docstring.
 class MetricDataListView(ElasticListAPIView):
     """Return events from Logstash data.
 

--- a/goldstone/test_utils.py
+++ b/goldstone/test_utils.py
@@ -51,15 +51,21 @@ class Setup(SimpleTestCase):
         """Do explicit database reseting.
 
         SimpleTestCase doesn't always reset the database to as much of an
-        initial state as we expect. And we want to reset the resource graph.
+        initial state as we expect. And we need reset the resource and resource
+        type graphs.
 
         """
+        from goldstone.addons.models import Addon
         from goldstone.core.models import PolyResource
         from goldstone.core import resource
         from goldstone.tenants.models import Tenant
 
         get_user_model().objects.all().delete()
         Tenant.objects.all().delete()
+
+        Addon.objects.all().delete()
+
+        resource.types = resource.Types()
 
         PolyResource.objects.non_polymorphic().all().delete()
         resource.instances.graph.clear()

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@
 
 [metadata]
 name = goldstone-server
-version = 0.7.1
+version = 0.7.2
 summary = goldstone-server
 license = Apache License, Version 2.0
 description-file = docs/README.md


### PR DESCRIPTION
These are the goldstone-server changes for adding support for add-on resource types and resource graph nodes to Goldstone.

It also bumps the version number in setup.cfg. Without this change, tox throws an exception.

Pylint:
* master: 9.65 / 10 / 9.82 / 10
* this pull request: 9.66 / 10 / 9.82 / 10

Unit tests are included. There are no meaningful interactive tests for this PR.
