### PR TITLE
Django-admin, who is not non-tenant-admin, can request and change tenant data, but can't get to the "tenant settings" page

### DIFF
--- a/client/js/views/settingsPageView.js
+++ b/client/js/views/settingsPageView.js
@@ -83,10 +83,10 @@ var SettingsPageView = GoldstoneBaseView2.extend({
                 $(self.el).find('[name="email"]').val(result.email);
 
                 // result object contains tenant_admin field (true|false)
-                if (result.tenant_admin) {
+                if (result.tenant_admin || result.is_superuser) {
 
                     // if true, render link to tenant admin settings page
-                    if (result.tenant_admin === true) {
+                    if (result.tenant_admin === true || result.is_superuser === true) {
                         self.renderTenantSettingsPageLink();
                     }
                 }

--- a/client/js/views/tenantSettingsPageView.js
+++ b/client/js/views/tenantSettingsPageView.js
@@ -144,6 +144,16 @@ var TenantSettingsPageView = GoldstoneBaseView2.extend({
                 $form.find('[name="os_name"]').val(result.os_name);
                 $form.find('[name="os_password"]').val(result.os_password);
                 $form.find('[name="os_username"]').val(result.os_username);
+
+                // in case of landing on this page via is_superuser === true,
+                // OpenStack settings are not a valid target for updating.
+                // Check for this via presence of the OpenStack tenant name
+                if(result.os_name === undefined) {
+
+                    // disable all form fields and update button
+                    $form.find('input').attr('disabled', 'true');
+                    $form.find('button').attr('disabled', true);
+                }
             })
             .fail(function(fail) {
                 goldstone.raiseInfo('could not load OpenStack settings');

--- a/goldstone/core/models.py
+++ b/goldstone/core/models.py
@@ -17,7 +17,7 @@ from django.db.models import CharField, IntegerField
 from django_extensions.db.fields import UUIDField, CreationDateTimeField, \
     ModificationDateTimeField
 from elasticsearch_dsl import String, Date, Integer, A
-from elasticsearch_dsl.query import Q, QueryString
+from elasticsearch_dsl.query import Q, QueryString      # pylint: disable=E0611
 from goldstone.drfes.models import DailyIndexDocType
 from goldstone.glogging.models import LogData, LogEvent
 from picklefield.fields import PickledObjectField
@@ -84,14 +84,19 @@ class MetricData(DailyIndexDocType):
 
     @classmethod
     def stats_agg(cls):
+        """Return extended statistics."""
+
         return A('extended_stats', field='value')
 
     @classmethod
     def units_agg(cls):
+        """Return term units."""
+
         return A('terms', field='unit')
 
 
 class ReportData(DailyIndexDocType):
+    """Report data model."""
 
     INDEX_PREFIX = 'goldstone_reports-'
 
@@ -119,8 +124,7 @@ class ApiPerfData(DailyIndexDocType):
     INDEX_PREFIX = 'goldstone-'
     SORT = '-@timestamp'
 
-    # Field declarations.  The types are generated dynamically, so PyCharm
-    # thinks the imports are unresolved references.
+    # Field declarations.
     response_status = Integer()
     creation_time = Date()
     component = String()
@@ -133,11 +137,13 @@ class ApiPerfData(DailyIndexDocType):
 
     @classmethod
     def stats_agg(cls):
+        """Return extended statistics."""
 
         return A('extended_stats', field='response_time')
 
     @classmethod
     def range_agg(cls):
+        """Return range information."""
 
         return A('range',
                  field='response_status',
@@ -153,11 +159,7 @@ class ApiPerfData(DailyIndexDocType):
 ######################################
 
 def _utc_now():
-    """Convenient, and possibly necessary.
-
-    :return: timezone aware current UTC datetime
-
-    """
+    """Return a timezone-aware current UTC datetime."""
     import arrow
 
     return arrow.utcnow().datetime

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -13730,6 +13730,16 @@ var TenantSettingsPageView = GoldstoneBaseView2.extend({
                 $form.find('[name="os_name"]').val(result.os_name);
                 $form.find('[name="os_password"]').val(result.os_password);
                 $form.find('[name="os_username"]').val(result.os_username);
+
+                // in case of landing on this page via is_superuser === true,
+                // OpenStack settings are not a valid target for updating.
+                // Check for this via presence of the OpenStack tenant name
+                if(result.os_name === undefined) {
+
+                    // disable all form fields and update button
+                    $form.find('input').attr('disabled', 'true');
+                    $form.find('button').attr('disabled', true);
+                }
             })
             .fail(function(fail) {
                 goldstone.raiseInfo('could not load OpenStack settings');

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -12905,10 +12905,10 @@ var SettingsPageView = GoldstoneBaseView2.extend({
                 $(self.el).find('[name="email"]').val(result.email);
 
                 // result object contains tenant_admin field (true|false)
-                if (result.tenant_admin) {
+                if (result.tenant_admin || result.is_superuser) {
 
                     // if true, render link to tenant admin settings page
-                    if (result.tenant_admin === true) {
+                    if (result.tenant_admin === true || result.is_superuser === true) {
                         self.renderTenantSettingsPageLink();
                     }
                 }

--- a/goldstone/tenants/tests_user.py
+++ b/goldstone/tenants/tests_user.py
@@ -1,4 +1,4 @@
-"""Unit tests for /tenants/<id>/users endpoints."""
+"""Unit tests for /tenants/<id>/users/ endpoints."""
 # Copyright 2015 Solinea, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,12 +24,6 @@ from goldstone.test_utils import Setup, create_and_login, login, \
     BAD_TOKEN, BAD_UUID, CONTENT_NOT_BLANK_USERNAME
 from .models import Tenant
 from .tests_tenants import TENANTS_ID_URL
-
-# HTTP response content.
-CONTENT_MISSING_OS_USERNAME = '"username":["This field may not be blank."]'
-CONTENT_MISSING_OS_NAME = '"tenant_name":["This field may not be blank."]'
-CONTENT_MISSING_OS_PASSWORD = '"password":["This field may not be blank."]'
-CONTENT_MISSING_OS_URL = '"auth_url":["This field may not be blank."]'
 
 # URLs used by this module.
 TENANTS_ID_USERS_URL = TENANTS_ID_URL + "users/"
@@ -166,19 +160,22 @@ class TenantsIdUsers(Setup):
                             "email": "a@b.com",
                             "default_tenant_admin": False,
                             "tenant_name": "tennet",
-                            "tenant_admin": True},
+                            "tenant_admin": True,
+                            "is_superuser": False},
                            {"username": "b",
                             "first_name": '',
                             "last_name": '',
                             "email": "b@b.com",
                             "default_tenant_admin": False,
-                            "tenant_admin": False},
+                            "tenant_admin": False,
+                            "is_superuser": False},
                            {"username": "c",
                             "first_name": '',
                             "last_name": '',
                             "email": "c@b.com",
                             "default_tenant_admin": False,
-                            "tenant_admin": False},
+                            "tenant_admin": False,
+                            "is_superuser": False},
                            ]
 
         # Make a tenant
@@ -275,12 +272,14 @@ class TenantsIdUsers(Setup):
                             "last_name": '',
                             "email": "a@b.com",
                             "tenant_admin": False,
+                            "is_superuser": False,
                             "default_tenant_admin": False},
                            {"username": "b",
                             "first_name": '',
                             "last_name": '',
                             "email": "b@b.com",
                             "tenant_admin": False,
+                            "is_superuser": False,
                             "default_tenant_admin": False}]
 
         # Make a tenant
@@ -461,6 +460,7 @@ class TenantsIdUsersId(Setup):
                              "last_name": "",
                              "email": "fred@fred.com",
                              "tenant_admin": True,
+                             "is_superuser": False,
                              "tenant_name": "tennent",
                              "default_tenant_admin": False},
                             {"username": "Traci",
@@ -468,6 +468,7 @@ class TenantsIdUsersId(Setup):
                              "last_name": "",
                              "email": '',
                              "tenant_admin": False,
+                             "is_superuser": False,
                              "default_tenant_admin": False},
                             ]
 
@@ -543,6 +544,7 @@ class TenantsIdUsersId(Setup):
              "last_name": "",
              "email": "",
              "tenant_admin": False,
+             "is_superuser": False,
              "default_tenant_admin": False},
             # PUTting to an unrecognized field.
             {"username": "Beth",
@@ -550,6 +552,7 @@ class TenantsIdUsersId(Setup):
              "last_name": "",
              "email": "",
              "tenant_admin": False,
+             "is_superuser": False,
              "default_tenant_admin": False},
         ]
 
@@ -620,6 +623,7 @@ class TenantsIdUsersId(Setup):
                              "last_name": "2",
                              "email": "x@y.com",
                              "tenant_admin": False,
+                             "is_superuser": False,
                              "default_tenant_admin": False}
 
         # Make a tenant.

--- a/goldstone/user/views.py
+++ b/goldstone/user/views.py
@@ -130,7 +130,6 @@ class UserSerializer(ModelSerializer):
                    "groups",
                    "is_staff",
                    "is_active",
-                   "is_superuser",
                    "password",
                    )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ django-polymorphic==0.7.1
 django-rest-params==1.0.2
 django-rest-swagger==0.2.9
 djangorestframework==3.1.0
-djoser==0.3.0
+djoser==0.3.1
 drf-extensions==0.2.7
 elasticsearch-curator==3.1.0
 elasticsearch-dsl==0.0.4

--- a/test/integration/tenantSettingsPageView_integrationTests.js
+++ b/test/integration/tenantSettingsPageView_integrationTests.js
@@ -37,7 +37,9 @@ describe('tenantSettingsPageView.js spec', function() {
     });
     describe('basic test for chart triggering', function() {
         it('renders view', function() {
+            this.testView.onClose();
             this.testView.render();
+            this.server.respond();
             this.testView.submitRequest();
             this.server.respond();
             this.testView.getTenantAndOSSettings();


### PR DESCRIPTION
GET /user/ will now return:

    {"last_login": "2015-07-20T05:41:41.768569Z",
      "username": "admin",
      "first_name": "",
      "last_name": "",
      "email": "root@localhost",
      "date_joined": "2015-07-20T05:41:41.768569Z",
      "tenant_admin": false,
      "is_superuser": true,
      "default_tenant_admin": false,
      "uuid": "6f73b75d-3eb9-4e80-a297-53cdf743eded"
    }

The change is the addition of the, "*is_superuser*," key.  Its value will be either *true* or *false*.

If true, the user is a Django admin. A.k.a., a Goldstone admin. If false, the user is a standard user account.

The name comes from the Django attribute of the same name. It's different than our other attributes, but it'd be nice to keep it identical to Django's attribute, and avoid an alias.

Pylint:
* master: 9.73 / 10 / 10 / 10
* this pull: 9.75 / 10 / 10 / 10