### PR TITLE
Support for opentrail audit filters

### DIFF
--- a/goldstone/core/models.py
+++ b/goldstone/core/models.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import arrow
 from django.conf import settings
 from django.db.models import CharField, IntegerField
 from django_extensions.db.fields import UUIDField, CreationDateTimeField, \
@@ -158,13 +159,6 @@ class ApiPerfData(DailyIndexDocType):
 # Resource graph types and instances #
 ######################################
 
-def _utc_now():
-    """Return a timezone-aware current UTC datetime."""
-    import arrow
-
-    return arrow.utcnow().datetime
-
-
 class PolyResource(PolymorphicModel):
     """The base type for resources.
 
@@ -191,7 +185,7 @@ class PolyResource(PolymorphicModel):
 
     created = CreationDateTimeField(editable=False,
                                     blank=True,
-                                    default=_utc_now)
+                                    default=arrow.utcnow().datetime)
     updated = ModificationDateTimeField(editable=True, blank=True)
 
     class Meta:               # pylint: disable=C0111,W0232,C1001

--- a/goldstone/core/models.py
+++ b/goldstone/core/models.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import arrow
 from django.conf import settings
 from django.db.models import CharField, IntegerField
 from django_extensions.db.fields import UUIDField, CreationDateTimeField, \
@@ -159,6 +158,19 @@ class ApiPerfData(DailyIndexDocType):
 # Resource graph types and instances #
 ######################################
 
+def _utc_now():
+    """Return a timezone-aware current UTC datetime.
+
+    This is needed for a model field's default. It's called every time a row is
+    created, and lambdas can't be used because they can't be serialized by
+    migrations.
+
+    """
+    import arrow
+
+    return arrow.utcnow().datetime
+
+
 class PolyResource(PolymorphicModel):
     """The base type for resources.
 
@@ -185,7 +197,7 @@ class PolyResource(PolymorphicModel):
 
     created = CreationDateTimeField(editable=False,
                                     blank=True,
-                                    default=arrow.utcnow().datetime)
+                                    default=_utc_now)
     updated = ModificationDateTimeField(editable=True, blank=True)
 
     class Meta:               # pylint: disable=C0111,W0232,C1001

--- a/goldstone/keystone/utils.py
+++ b/goldstone/keystone/utils.py
@@ -118,8 +118,8 @@ def update_keystone_nodes():
        - updated from the cloud if they are already in the graph.
 
     """
-    from goldstone.core.models import User, Project
+    from goldstone.core.models import User, Project, Group, Domain
     from goldstone.core.utils import process_resource_type
 
-    process_resource_type(User)
-    process_resource_type(Project)
+    for entry in [Domain, Project, Group, User]:
+        process_resource_type(entry)


### PR DESCRIPTION
This is the server-side change for the opentrail audit filters ticket.

The corresponding django-opentrail pull request will have installation and testing instructions, when I create it in a few minutes.

Pylint:
* master: 9.76 / 10 / 10 / 10
* this branch: 9.77 / 10 / 10 / 10