### PR TITLE
bumped docker-compose releases

### DIFF
--- a/bin/build_images.sh
+++ b/bin/build_images.sh
@@ -22,7 +22,7 @@ TOP_DIR=${GS_PROJ_TOP_DIR:-${PROJECT_HOME}/goldstone-server}
 DIST_DIR=${TOP_DIR}/dist
 GIT_BRANCH=$(git symbolic-ref --short HEAD)
 GIT_COMMIT=$(git rev-parse --short HEAD)
-TAGGED=false
+TAGGED=true
 TAG=""
 
 GS_APP_DIR=${TOP_DIR}/docker/Dockerfiles/goldstone-app
@@ -50,8 +50,8 @@ for arg in "$@" ; do
             DOCKER_VM="${arg#*=}"
             shift
         ;;
-        --tagged)
-            TAGGED=true
+        --untagged)
+            TAGGED=false
         ;;
         --tag=*)
             TAG="${arg#*=}"
@@ -120,7 +120,11 @@ if [[ $TAGGED == 'true' ]] ; then
         echo "Building ${REGISTRY_ORG}/${folder##*/}..."
         echo "##########################################################"
         if [[ ${TAG} == "" ]] ; then
-            NEXT_TAG=`docker-tag-naming bump ${REGISTRY_ORG}/${folder##*/} $GIT_BRANCH --commit-id $GIT_COMMIT`
+            if [[ ${GIT_BRANCH} == "master" ]] ; then
+                NEXT_TAG=`docker-tag-naming bump ${REGISTRY_ORG}/${folder##*/} release --commit-id $GIT_COMMIT`
+            else
+                NEXT_TAG=`docker-tag-naming bump ${REGISTRY_ORG}/${folder##*/} develop --commit-id $GIT_COMMIT`
+            fi
         else
             NEXT_TAG=${TAG}
         fi

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@
 
 # Goldstone Proxy & Static
 gsweb:
-  image: solinea/goldstone-web:v4-bedb7ee-docker_celery
+  image: solinea/goldstone-web:v1-3bd1d52-release
   volumes:
     - ./config/goldstone-web/nginx.conf:/etc/nginx/nginx.conf
     - ./config/goldstone-web/conf.d:/etc/nginx/conf.d
@@ -30,7 +30,7 @@ gsweb:
 
 # Goldstone Server Container
 gsapp:
-  image: solinea/goldstone-app:v4-bedb7ee-docker_celery
+  image: solinea/goldstone-app:v1-3bd1d52-release
   env_file: ./config/goldstone-prod.env
   volumes:
     - ./config/goldstone-app:/home/app/config
@@ -47,7 +47,7 @@ gsapp:
 
 # Database Container
 gsdb:
-  image: solinea/goldstone-db:v4-bedb7ee-docker_celery
+  image: solinea/goldstone-db:v1-3bd1d52-release
   env_file: ./config/goldstone-prod.env
   volumes_from:
     - gsdbdvc
@@ -60,7 +60,7 @@ gsdb:
 
 # Database Data Volume Container
 gsdbdvc:
-  image: solinea/goldstone-db-dvc:v4-bedb7ee-docker_celery
+  image: solinea/goldstone-db-dvc:v1-3bd1d52-release
   volumes:
     - /var/lib/postgresql/data
   log_driver: "syslog"
@@ -70,7 +70,7 @@ gsdbdvc:
 
 # Logstash Container
 gslog:
-  image: solinea/goldstone-log:v4-bedb7ee-docker_celery
+  image: solinea/goldstone-log:v1-3bd1d52-release
   command: logstash -f /logstash/conf.d -w 1
   volumes:
     - ./config/goldstone-log/conf.d:/logstash/conf.d
@@ -88,7 +88,7 @@ gslog:
 
 # Elasticsearch Container
 gssearch:
-  image: solinea/goldstone-search:v4-bedb7ee-docker_celery
+  image: solinea/goldstone-search:v1-3bd1d52-release
   volumes:
     - ./config/goldstone-search:/usr/share/elasticsearch/config
   ports:
@@ -101,7 +101,7 @@ gssearch:
 
 # Celery Task Queue Container
 gstaskq:
-  image: solinea/goldstone-task-queue:v4-bedb7ee-docker_celery
+  image: solinea/goldstone-task-queue:v1-3bd1d52-release
   ports:
     - "6379:6379"
   log_driver: "syslog"


### PR DESCRIPTION
there was a minor amount of code added to the build_images.sh file.  I used it to build the images that this release uses with, with no issues.  As discussed earlier, I'm going to self-close this PR and tag master with a new release number.