### PR TITLE
changed bug link from to point at freshdesk instead of gh issues

### DIFF
--- a/goldstone/templates/base.html
+++ b/goldstone/templates/base.html
@@ -134,7 +134,7 @@
             <!-- feedback icon -->
             <ul class="nav navbar-nav navbar pull-right">
                 <h4>
-                <a href="https://github.com/Solinea/goldstone-server/issues" target="_blank">
+                <a href="https://solinea.freshdesk.com/support/tickets/new" target="_blank">
                     <i class="fa fa-bug pull-right"></i>
                 </a>
                 </h4>


### PR DESCRIPTION
After discussion with @sethfox, we decided to change the link behind the bug icon to go to the new issue form in freshdesk.  