### PR TITLE
django-goldstone-addon-base tox tests failing

### DIFF
--- a/goldstone/core/tests_resource_api_1.py
+++ b/goldstone/core/tests_resource_api_1.py
@@ -67,7 +67,7 @@ class CoreResourceTypes(Setup):
         mock_rt_graph = Types()
         mock_rt_graph.graph.clear()
 
-        with patch("goldstone.core.views.types", mock_rt_graph):
+        with patch("goldstone.core.resource.types", mock_rt_graph):
             response = self.client.get(
                 RESTYPE_URL,
                 HTTP_AUTHORIZATION=AUTHORIZATION_PAYLOAD % token)
@@ -329,6 +329,25 @@ class CoreResourceTypes(Setup):
                      u"<class 'goldstone.core.models.Addon'>"},
                     ]
 
+        # This code is for ticket #105611698. Coming into this test, the
+        # resource types graph should be in a known state, having been
+        # initialized by goldstone.test_utils.Setup.setUp(). But sometimes it
+        # isn't. This code block checks for a known initial state and asserts a
+        # test failure if it's not there.
+        bad = False
+
+        for entry in resource.types.graph.nodes():
+            try:
+                entry.display_attributes()
+            except Exception as exc:        # pylint: disable=W0703
+                print "? %s doesn't have display_attributes, exception: %s" % \
+                    (entry, exc.message)
+                bad = True
+
+        self.assertFalse(bad, msg="initial test condition is bad")
+
+        # End of ticket #105611698 code.
+
         # Create the nodes for the test.
         for nodetype, native_id, native_name, attributes in NODES:
             if nodetype == Host:
@@ -376,7 +395,7 @@ class CoreResourceTypesDetail(Setup):
         mock_rt_graph.graph.clear()
 
         # Note, we ask for a resource type that normally exists.
-        with patch("goldstone.core.views.types", mock_rt_graph):
+        with patch("goldstone.core.resource.types", mock_rt_graph):
             response = self.client.get(
                 RESTYPE_DETAIL_URL % "<class 'goldstone.core.models.QOSSpec'>",
                 HTTP_AUTHORIZATION=AUTHORIZATION_PAYLOAD % token)
@@ -524,7 +543,7 @@ class AuthToken(Setup):
         mock_rt_graph = Types()
         mock_rt_graph.graph.clear()
 
-        with patch("goldstone.core.views.types", mock_rt_graph):
+        with patch("goldstone.core.resource.types", mock_rt_graph):
             response = self.client.get(
                 RESTYPE_URL,
                 HTTP_AUTHORIZATION=AUTHORIZATION_PAYLOAD % token)
@@ -536,7 +555,7 @@ class AuthToken(Setup):
         # should fail because of the tokens' expiration.
         expire_auth_tokens()
 
-        with patch("goldstone.core.views.types", mock_rt_graph):
+        with patch("goldstone.core.resource.types", mock_rt_graph):
             response = self.client.get(
                 RESTYPE_URL,
                 HTTP_AUTHORIZATION=AUTHORIZATION_PAYLOAD % token)

--- a/goldstone/core/views.py
+++ b/goldstone/core/views.py
@@ -21,7 +21,6 @@ from goldstone.drfes.views import ElasticListAPIView, SimpleAggView, \
     DateHistogramAggView
 from goldstone.utils import TopologyMixin
 
-from goldstone.core.resource import types
 from goldstone.core import resource
 from .models import MetricData, ReportData, PolyResource, EventData, \
     ApiPerfData
@@ -385,13 +384,13 @@ class ResourceTypeList(ListAPIView):
         nodes = [{"display_attributes": entry.display_attributes(),
                   "unique_id": entry.unique_class_id(),
                   "present": bool(resource.instances.nodes_of_type(entry))}
-                 for entry in types.graph]
+                 for entry in resource.types.graph.nodes()]
 
         # Gather the edges.
         edges = [{"from": str(entry[0]),
                   "to": str(entry[1]),
                   "type": entry[2][TYPE]}
-                 for entry in types.graph.edges_iter(data=True)]
+                 for entry in resource.types.graph.edges_iter(data=True)]
 
         return Response({"nodes": nodes, "edges": edges})
 
@@ -435,7 +434,7 @@ class ResourceTypeRetrieve(RetrieveAPIView):
         """
 
         # Get the type that matches the supplied id.
-        target_type = types.get_type(unique_id)
+        target_type = resource.types.get_type(unique_id)
 
         result = []
 

--- a/goldstone/glogging/serializers.py
+++ b/goldstone/glogging/serializers.py
@@ -15,7 +15,7 @@
 from goldstone.drfes.serializers import ReadOnlyElasticSerializer
 
 
-class LogDataSerializer(ReadOnlyElasticSerializer):
+class LogDataSerializer(ReadOnlyElasticSerializer):  # pylint: disable=W0223
     """Serializer for ES log data. Excludes several uninteresting fields."""
 
     class Meta:        # pylint: disable=C1001,W0232
@@ -25,9 +25,9 @@ class LogDataSerializer(ReadOnlyElasticSerializer):
                    'syslog_pri', 'syslog5424_pri', 'syslog5424_host', 'type')
 
 
-class LogAggSerializer(ReadOnlyElasticSerializer):
-    """Custom serializer to manipulate the aggregation that comes back from ES.
-    """
+class LogAggSerializer(ReadOnlyElasticSerializer):  # pylint: disable=W0223
+    """Custom serializer to manipulate the aggregation that comes back from
+    ES."""
 
     def to_representation(self, instance):
         """Create serialized representation of aggregate log data.
@@ -36,6 +36,7 @@ class LogAggSerializer(ReadOnlyElasticSerializer):
         etc., then the detailed aggregation data which will be a nested
         structure.  The number of layers will depend on whether the host
         aggregation was done.
+
         """
 
         timestamps = [i['key'] for i in instance.per_interval['buckets']]


### PR DESCRIPTION
A unit test failed on Alex's laptop. I couldn't reproduce it, so I added code to check for an invariant initial condition.

If the initial condition isn't correct, it'll display error messages that should help us isolate this problem.

This also fixes an unrelated bug in resource type references, and some pylint errors.

Pylint:
* master: 9.77 / 10 / 9.96 / 10
* this pull: 9.78 / 10 / 9.96 / 10