### PR TITLE
changed the parent of db-dvc to our postgres image

### DIFF
--- a/docker/Dockerfiles/goldstone-app/docker_entrypoint.sh
+++ b/docker/Dockerfiles/goldstone-app/docker_entrypoint.sh
@@ -60,7 +60,7 @@ exec celery worker --app goldstone --queues default --beat --purge \
 
 if [[ $GS_DEV_ENV == "true" ]] ; then
     echo "Starting Django server"
-    exec python manage.py runserver --settings=${DJANGO_SETTINGS_MODULE} "$@"
+    exec python manage.py runserver --settings=${DJANGO_SETTINGS_MODULE} 0.0.0.0:8000 "$@"
 else
     echo Starting Gunicorn.
     exec gunicorn ${GUNICORN_RELOAD} \

--- a/docker/Dockerfiles/goldstone-db-dvc/Dockerfile
+++ b/docker/Dockerfiles/goldstone-db-dvc/Dockerfile
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM postgres:9.4
+FROM solinea/postgres:v1-709cdb3-release
+
 MAINTAINER Luke Heidecke <luke@solinea.com>
 
 VOLUME /var/lib/postgresql/data


### PR DESCRIPTION
changed the parent of db-dvc to our postgres image rather than the generic one.

To verify, you can look at the before/after image graph

Before:

```
docker pull centurylink/image-graph
docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
  centurylink/image-graph > docker_images.png
```
When you view the docker_images.png file and notice the parent of goldstoneserver_gsdbdvc is postgres:9.4.

After:

```
docker rm $(docker ps -a -q)
docker rmi goldstoneserver_gsappdev_1
docker rmi goldstoneserver_gsdbdvc_1
docker-compose -f docker-compose-dev.yml build
docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
  centurylink/image-graph > docker_images.png
```

When you view the new file, the goldstoneserver_gsdbdvc image should be a descendant of solinea/postgres