### PR TITLE
added log output configuration to limit the historical log output of …

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -26,6 +26,10 @@ gsappdev:
     - gsdb
     - gssearch
     - gstaskq
+  log_driver: "json-file"
+  log_opt:
+    max-size: "100k"
+    max-file: "10"
 
 # Database Container
 gsdb:
@@ -35,12 +39,20 @@ gsdb:
     - gsdbdvc
   ports:
     - "5432:5432"
+  log_driver: "json-file"
+  log_opt:
+    max-size: "100k"
+    max-file: "10"
 
 # Database Data Volume Container
 gsdbdvc:
   build: ./docker/Dockerfiles/goldstone-db-dvc
   volumes:
     - /var/lib/postgresql/data
+  log_driver: "json-file"
+  log_opt:
+    max-size: "100k"
+    max-file: "10"
 
 # Logstash Container
 gslog:
@@ -55,6 +67,10 @@ gslog:
     - "5516:5516"
   links:
     - gssearch
+  log_driver: "json-file"
+  log_opt:
+    max-size: "100k"
+    max-file: "10"
 
 # Elasticsearch Container
 gssearch:
@@ -64,12 +80,20 @@ gssearch:
   ports:
     - "9200:9200"
     - "9300:9300"
+  log_driver: "json-file"
+  log_opt:
+    max-size: "100k"
+    max-file: "10"
 
 # Celery Task Queue Container
 gstaskq:
- build: ./docker/Dockerfiles/goldstone-task-queue
- ports:
+  build: ./docker/Dockerfiles/goldstone-task-queue
+  ports:
     - "6379:6379"
+  log_driver: "json-file"
+  log_opt:
+    max-size: "100k"
+    max-file: "10"
 
 # Kibana
 gskibana:
@@ -78,3 +102,7 @@ gskibana:
     - "5601:5601"
   links:
     - "gssearch:elasticsearch"
+  log_driver: "json-file"
+  log_opt:
+    max-size: "100k"
+    max-file: "10"

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -25,6 +25,10 @@ gsweb:
     - "8888:8888"
   links:
     - gsapp:gsapp
+  log_driver: "json-file"
+  log_opt:
+    max-size: "100k"
+    max-file: "10"
 
 # Goldstone Server Container
 gsapp:
@@ -39,6 +43,10 @@ gsapp:
     - gsdb
     - gssearch
     - gstaskq
+  log_driver: "json-file"
+  log_opt:
+    max-size: "100k"
+    max-file: "10"
 
 # Database Container
 gsdb:
@@ -48,12 +56,20 @@ gsdb:
     - "5432:5432"
   volumes_from:
     - gsdbdvc
+  log_driver: "json-file"
+  log_opt:
+    max-size: "100k"
+    max-file: "10"
 
 # Database Data Volume Container
 gsdbdvc:
   image: solinea/goldstone-db-dvc
   volumes:
     - /var/lib/postgresql/data
+  log_driver: "json-file"
+  log_opt:
+    max-size: "100k"
+    max-file: "10"
 
 # Logstash Container
 gslog:
@@ -68,6 +84,10 @@ gslog:
     - "5516:5516"
   links:
     - gssearch
+  log_driver: "json-file"
+  log_opt:
+    max-size: "100k"
+    max-file: "10"
 
 # Elasticsearch Container
 gssearch:
@@ -77,9 +97,17 @@ gssearch:
   ports:
     - "9200:9200"
     - "9300:9300"
+  log_driver: "json-file"
+  log_opt:
+    max-size: "100k"
+    max-file: "10"
 
 # Celery Task Queue Container
 gstaskq:
   image: solinea/goldstone-task-queue
   ports:
     - "6379:6379"
+  log_driver: "json-file"
+  log_opt:
+    max-size: "100k"
+    max-file: "10"


### PR DESCRIPTION
…long-lived containers.  Arbitrarily decided that 100KB with 10 historical versions was sufficient.