### PR TITLE
Sets a lower limit of '2m' to compute viz' ...

### DIFF
--- a/client/js/collections/multiMetricComboCollection.js
+++ b/client/js/collections/multiMetricComboCollection.js
@@ -88,7 +88,10 @@ var MultiMetricComboCollection = Backbone.Collection.extend({
 
         ns.reportParams.end = +new Date();
         ns.reportParams.start = (+new Date() - (ns.globalLookback * 1000 * 60));
-        ns.reportParams.interval = '' + Math.max(1, (ns.globalLookback / 24)) + 'm';
+
+        // set a lower limit to the interval of '2m'
+        // in order to avoid the sawtooth effect
+        ns.reportParams.interval = '' + Math.max(2, (ns.globalLookback / 24)) + 'm';
 
         _.each(self.defaults.metricNames, function(prefix) {
 

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -3990,7 +3990,10 @@ var MultiMetricComboCollection = Backbone.Collection.extend({
 
         ns.reportParams.end = +new Date();
         ns.reportParams.start = (+new Date() - (ns.globalLookback * 1000 * 60));
-        ns.reportParams.interval = '' + Math.max(1, (ns.globalLookback / 24)) + 'm';
+
+        // set a lower limit to the interval of '2m'
+        // in order to avoid the sawtooth effect
+        ns.reportParams.interval = '' + Math.max(2, (ns.globalLookback / 24)) + 'm';
 
         _.each(self.defaults.metricNames, function(prefix) {
 


### PR DESCRIPTION
...in order to avoid the sawtooth effect.

Pictured below, 15 minute lookback, but interval has been lower-bound to 2m interval to avoid sawtooth.

![image](https://cloud.githubusercontent.com/assets/5633015/11220731/312e8c48-8d16-11e5-9694-4a8e9a00c698.png)


