### PR TITLE
Event timeline

### DIFF
--- a/client/js/views/eventTimelineView.js
+++ b/client/js/views/eventTimelineView.js
@@ -165,7 +165,7 @@ var EventTimelineView = GoldstoneBaseView.extend({
 
                 return "" +
                     "Host: " + d.host + "<br>" +
-                    d.doc_type + " (click event line to persist popup info)<br>" +
+                    d.doc_type + "<br>" +
                     // "uuid: " + d.id + "<br>" +
                     "Created: " + d.timestamp + "<br>";
                     // "Message: " + d.log_message + "<br>";
@@ -367,20 +367,7 @@ var EventTimelineView = GoldstoneBaseView.extend({
                 return ns.color(ns.uniqueEventTypes.indexOf(d.doc_type) % ns.color.range().length);
             })
             .on("mouseover", ns.tooltip.show)
-            .on("click", function() {
-                if (ns.tooltip.pause === undefined) {
-                    ns.tooltip.pause = true;
-                } else {
-                    ns.tooltip.pause = !ns.tooltip.pause;
-                }
-                if (ns.tooltip.pause === false) {
-                    ns.tooltip.hide();
-                }
-            })
             .on("mouseout", function() {
-                if (ns.tooltip.pause) {
-                    return;
-                }
                 ns.tooltip.hide();
             });
 

--- a/client/js/views/eventTimelineView.js
+++ b/client/js/views/eventTimelineView.js
@@ -59,7 +59,7 @@ var EventTimelineView = GoldstoneBaseView.extend({
         var self = this;
 
         this.listenTo(this.collection, 'sync', this.update);
-        this.listenTo(this. collection, 'error', this.dataErrorMessage);
+        this.listenTo(this.collection, 'error', this.dataErrorMessage);
 
         this.on('lookbackSelectorChanged', function() {
             self.updateSettings();
@@ -115,7 +115,7 @@ var EventTimelineView = GoldstoneBaseView.extend({
         // you can change the value in colorArray to select
         // a particular number of different colors
         var colorArray = new GoldstoneColors().get('colorSets');
-        ns.color = d3.scale.ordinal().range(colorArray.distinct[1]);
+        ns.color = d3.scale.ordinal().range(colorArray.distinct[3]);
 
         /*
          * The graph and axes
@@ -154,21 +154,18 @@ var EventTimelineView = GoldstoneBaseView.extend({
             })
             .html(function(d) {
 
-                d.host = d.traits.host || 'No host logged';
-                d.log_message = d.log_message || 'No message logged';
-
-                if (d.log_message.length > 280) {
-                    d.log_message = d.log_message.slice(0, 300) + "...";
-                }
                 d.doc_type = d.doc_type || 'No event type logged';
+                d.initiator_name = d.traits.initiator_name || 'No initiator logged';
+                d.target_name = d.traits.target_name || 'No target logged';
+                d.outcome = d.traits.outcome || 'No outcome logged';
                 d.timestamp = d.timestamp || 'No date logged';
 
                 return "" +
-                    "Host: " + d.host + "<br>" +
-                    d.doc_type + "<br>" +
-                    // "uuid: " + d.id + "<br>" +
+                    "Doc type: " + d.doc_type + "<br>" +
+                    "Initiator: " + d.initiator_name + "<br>" +
+                    "Target: " + d.target_name + "<br>" +
+                    "Outcome: " + d.outcome + "<br>" +
                     "Created: " + d.timestamp + "<br>";
-                    // "Message: " + d.log_message + "<br>";
             });
 
         ns.graph.call(ns.tooltip);
@@ -279,7 +276,7 @@ var EventTimelineView = GoldstoneBaseView.extend({
 
             ns.filter[item] = ns.filter[item] || {
                 active: true,
-                color: ns.color(ns.uniqueEventTypes.indexOf(item) % ns.color.range().length),
+                // color: ns.color(ns.uniqueEventTypes.indexOf(item) % ns.color.range().length),
                 displayName: itemSpaced
             };
 
@@ -339,21 +336,21 @@ var EventTimelineView = GoldstoneBaseView.extend({
 
         var rectangle = ns.graph.selectAll("rect")
 
-            // bind data to d3 nodes and create uniqueness based on
-            // th.timestamparam. This could possibly create some
-            // issues due to duplication of a supposedly unique
-            // param, but has not yet been a problem in practice.
-            .data(ns.dataset, function(d) {
-                return d.timestamp;
-            });
+        // bind data to d3 nodes and create uniqueness based on
+        // th.timestamparam. This could possibly create some
+        // issues due to duplication of a supposedly unique
+        // param, but has not yet been a problem in practice.
+        .data(ns.dataset, function(d) {
+            return d.timestamp;
+        });
 
         // enters at wider width and transitions to lesser width for a
         // dynamic resizing effect
         rectangle.enter()
             .append("rect")
-            .attr("x", ns.width)
+            .attr("x", ns.margin.left)
             .attr("y", ns.h.padding + 1)
-            .attr("width", 5)
+            .attr("width", 2)
             .attr("height", ns.h.main - ns.h.padding - 2)
             .attr("class", "single-event")
             .style("opacity", function(d) {
@@ -364,7 +361,15 @@ var EventTimelineView = GoldstoneBaseView.extend({
                 return self.visibilityByFilter(d);
             })
             .attr("fill", function(d) {
-                return ns.color(ns.uniqueEventTypes.indexOf(d.doc_type) % ns.color.range().length);
+                var result;
+                if (d && d.traits && d.traits.outcome) {
+                    result = d.traits.outcome;
+
+                    // 0: green, 1: blue, 2: orange
+                    return result === 'success' ? ns.color(0) : result === 'pending' ? ns.color(1) : ns.color(2);
+                } else {
+                    return ns.color(2);
+                }
             })
             .on("mouseover", ns.tooltip.show)
             .on("mouseout", function() {
@@ -404,10 +409,6 @@ var EventTimelineView = GoldstoneBaseView.extend({
     render: function() {
         this.$el.html(this.template());
 
-        // commented out, as the settings are determined by the
-        // global lookback selector
-        // $('#modal-container-' + this.el.slice(1)).append(this.eventSettingModal());
-
         // append the modal that is triggered by
         // clicking the filter icon
         $('#modal-container-' + this.el.slice(1)).append(this.eventFilterModal());
@@ -443,11 +444,6 @@ var EventTimelineView = GoldstoneBaseView.extend({
         '<div id = "goldstone-event-panel" class="panel panel-primary">' +
         '<div class="panel-heading">' +
         '<h3 class="panel-title"><i class="fa fa-tasks"></i> <%= this.defaults.chartTitle %>' +
-
-        // cog icon
-        // '<i class="fa fa-cog pull-right" data-toggle="modal"' +
-        // 'data-target="#modal-settings-<%= this.el.slice(1) %>' +
-        // '"></i>' +
 
         // filter icon
         '<i class="fa fa-filter pull-right" data-toggle="modal"' +
@@ -507,69 +503,6 @@ var EventTimelineView = GoldstoneBaseView.extend({
         '</div>' +
         '</div>' +
         '</div>'
-    ),
-
-    eventSettingModal: _.template(
-        // event settings modal
-        // don't render if using global refresh/lookback
-        '<div class="modal fade" id="modal-settings-<%= this.el.slice(1) %>' +
-        '" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">' +
-        '<div class="modal-dialog">' +
-        '<div class="modal-content">' +
-        '<div class="modal-header">' +
-        '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>' +
-        '<h4 class="modal-title" id="myModalLabel">Chart Range Settings</h4>' +
-        '</div>' +
-        '<div class="modal-body">' +
-
-        // insert start/end form elements:
-
-        '<form class="form-horizontal" role="form">' +
-        '<div class="form-group">' +
-        '<label for="lookbackRange" class="col-sm-2 control-label">Lookback: </label>' +
-        '<div class="col-sm-5">' +
-        '<div class="input-group">' +
-        '<select class="form-control" id="lookbackRange">' +
-        '<option value="15">15 minutes</option>' +
-        '<option value="60" selected>1 hour</option>' +
-        '<option value="360">6 hours</option>' +
-        '<option value="1440">1 day</option>' +
-        '</select>' +
-        '</div>' +
-        '</div>' +
-        '</div>' +
-        '</form>' +
-
-        // end of new start/end elements
-
-        '<form class="form-horizontal" role="form">' +
-        '<div class="form-group">' +
-        '<label for="eventAutoRefresh" class="col-sm-2 control-label">Refresh: </label>' +
-        '<div class="col-sm-5">' +
-        '<div class="input-group">' +
-        '<span class="input-group-addon">' +
-        '<input type="checkbox" class="eventAutoRefresh" checked>' +
-        '</span>' +
-        '<select class="form-control" id="eventAutoRefreshInterval">' +
-        '<option value="5">5 seconds</option>' +
-        '<option value="15">15 seconds</option>' +
-        '<option value="30" selected>30 seconds</option>' +
-        '<option value="60">1 minute</option>' +
-        '<option value="300">5 minutes</option>' +
-        '</select>' +
-        '</div>' +
-        '</div>' +
-        '</div>' +
-        '</form>' +
-        '</div>' +
-        '<div class="modal-footer">' +
-        '<div class="form-group">' +
-        '<button type="button" id="eventSettingsUpdateButton-<%= this.el.slice(1) %>' +
-        '" class="btn btn-primary" data-dismiss="modal">Update</button>' +
-        '</div>' +
-        '</div>' +
-        '</div>' +
-        '</div>' +
-        '</div>'
     )
+
 });

--- a/client/js/views/eventTimelineView.js
+++ b/client/js/views/eventTimelineView.js
@@ -378,7 +378,6 @@ var EventTimelineView = GoldstoneBaseView.extend({
 
         rectangle
             .transition()
-            .attr("width", 2)
             .attr("x", function(d) {
                 return ns.xScale(d.timestamp);
             });

--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -27,7 +27,7 @@ With each browser page refresh, the client initialization process includes parsi
 <a name="import"></a>
 ## How to import a new .po file into the front-end i18n scheme so it's available as a selection in the client.
 
-When adding a new .po file, keep in mind that the actual name of the file prior to the `.po` (eg: _Latin_ from **Latin.po**) is what will be used to dynamically populate the choice of languages that can be selected in the client via the settings page. Capitalization will be carried over, so be sure to name your .po file exactly as you'd like it applied as a language choice.
+When adding a new .po file, remember that the file's name prior to the `.po` (eg: _Latin_ from **Latin.po**) will be used to dynamically populate the language choices in the client's settings page. Capitalization will be carried over, so be sure to name your .po file exactly as you'd like to see it as a language choice.
 
 Adding a file to or changing a file in `goldstone/static/i18n/po_files` (with the `grunt watch` task running) will trigger a re-rendering of `goldstone/static/i18n/po_json/i18n_combined.json`. This file is used by the Jed.js library as described in the section above.
 

--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -27,7 +27,7 @@ With each browser page refresh, the client initialization process includes parsi
 <a name="import"></a>
 ## How to import a new .po file into the front-end i18n scheme so it's available as a selection in the client.
 
-When adding a new .po file, keep in mind that the actual name of the file prior to the `.po` (eg: _Bocce_ from **Bocce.po**) is what will be used to dynamically populate the choice of languages that can be selected in the client via the settings page. Capitalization will be carried over, so be sure to name your .po file exactly as you'd like it applied as a language choice.
+When adding a new .po file, keep in mind that the actual name of the file prior to the `.po` (eg: _Latin_ from **Latin.po**) is what will be used to dynamically populate the choice of languages that can be selected in the client via the settings page. Capitalization will be carried over, so be sure to name your .po file exactly as you'd like it applied as a language choice.
 
 Adding a file to or changing a file in `goldstone/static/i18n/po_files` (with the `grunt watch` task running) will trigger a re-rendering of `goldstone/static/i18n/po_json/i18n_combined.json`. This file is used by the Jed.js library as described in the section above.
 

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -6294,7 +6294,7 @@ var EventTimelineView = GoldstoneBaseView.extend({
 
                 return "" +
                     "Host: " + d.host + "<br>" +
-                    d.doc_type + " (click event line to persist popup info)<br>" +
+                    d.doc_type + "<br>" +
                     // "uuid: " + d.id + "<br>" +
                     "Created: " + d.timestamp + "<br>";
                     // "Message: " + d.log_message + "<br>";
@@ -6496,20 +6496,7 @@ var EventTimelineView = GoldstoneBaseView.extend({
                 return ns.color(ns.uniqueEventTypes.indexOf(d.doc_type) % ns.color.range().length);
             })
             .on("mouseover", ns.tooltip.show)
-            .on("click", function() {
-                if (ns.tooltip.pause === undefined) {
-                    ns.tooltip.pause = true;
-                } else {
-                    ns.tooltip.pause = !ns.tooltip.pause;
-                }
-                if (ns.tooltip.pause === false) {
-                    ns.tooltip.hide();
-                }
-            })
             .on("mouseout", function() {
-                if (ns.tooltip.pause) {
-                    return;
-                }
                 ns.tooltip.hide();
             });
 

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -6507,7 +6507,6 @@ var EventTimelineView = GoldstoneBaseView.extend({
 
         rectangle
             .transition()
-            .attr("width", 2)
             .attr("x", function(d) {
                 return ns.xScale(d.timestamp);
             });

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -6188,7 +6188,7 @@ var EventTimelineView = GoldstoneBaseView.extend({
         var self = this;
 
         this.listenTo(this.collection, 'sync', this.update);
-        this.listenTo(this. collection, 'error', this.dataErrorMessage);
+        this.listenTo(this.collection, 'error', this.dataErrorMessage);
 
         this.on('lookbackSelectorChanged', function() {
             self.updateSettings();
@@ -6244,7 +6244,7 @@ var EventTimelineView = GoldstoneBaseView.extend({
         // you can change the value in colorArray to select
         // a particular number of different colors
         var colorArray = new GoldstoneColors().get('colorSets');
-        ns.color = d3.scale.ordinal().range(colorArray.distinct[1]);
+        ns.color = d3.scale.ordinal().range(colorArray.distinct[3]);
 
         /*
          * The graph and axes
@@ -6283,21 +6283,18 @@ var EventTimelineView = GoldstoneBaseView.extend({
             })
             .html(function(d) {
 
-                d.host = d.traits.host || 'No host logged';
-                d.log_message = d.log_message || 'No message logged';
-
-                if (d.log_message.length > 280) {
-                    d.log_message = d.log_message.slice(0, 300) + "...";
-                }
                 d.doc_type = d.doc_type || 'No event type logged';
+                d.initiator_name = d.traits.initiator_name || 'No initiator logged';
+                d.target_name = d.traits.target_name || 'No target logged';
+                d.outcome = d.traits.outcome || 'No outcome logged';
                 d.timestamp = d.timestamp || 'No date logged';
 
                 return "" +
-                    "Host: " + d.host + "<br>" +
-                    d.doc_type + "<br>" +
-                    // "uuid: " + d.id + "<br>" +
+                    "Doc type: " + d.doc_type + "<br>" +
+                    "Initiator: " + d.initiator_name + "<br>" +
+                    "Target: " + d.target_name + "<br>" +
+                    "Outcome: " + d.outcome + "<br>" +
                     "Created: " + d.timestamp + "<br>";
-                    // "Message: " + d.log_message + "<br>";
             });
 
         ns.graph.call(ns.tooltip);
@@ -6408,7 +6405,7 @@ var EventTimelineView = GoldstoneBaseView.extend({
 
             ns.filter[item] = ns.filter[item] || {
                 active: true,
-                color: ns.color(ns.uniqueEventTypes.indexOf(item) % ns.color.range().length),
+                // color: ns.color(ns.uniqueEventTypes.indexOf(item) % ns.color.range().length),
                 displayName: itemSpaced
             };
 
@@ -6468,21 +6465,21 @@ var EventTimelineView = GoldstoneBaseView.extend({
 
         var rectangle = ns.graph.selectAll("rect")
 
-            // bind data to d3 nodes and create uniqueness based on
-            // th.timestamparam. This could possibly create some
-            // issues due to duplication of a supposedly unique
-            // param, but has not yet been a problem in practice.
-            .data(ns.dataset, function(d) {
-                return d.timestamp;
-            });
+        // bind data to d3 nodes and create uniqueness based on
+        // th.timestamparam. This could possibly create some
+        // issues due to duplication of a supposedly unique
+        // param, but has not yet been a problem in practice.
+        .data(ns.dataset, function(d) {
+            return d.timestamp;
+        });
 
         // enters at wider width and transitions to lesser width for a
         // dynamic resizing effect
         rectangle.enter()
             .append("rect")
-            .attr("x", ns.width)
+            .attr("x", ns.margin.left)
             .attr("y", ns.h.padding + 1)
-            .attr("width", 5)
+            .attr("width", 2)
             .attr("height", ns.h.main - ns.h.padding - 2)
             .attr("class", "single-event")
             .style("opacity", function(d) {
@@ -6493,7 +6490,15 @@ var EventTimelineView = GoldstoneBaseView.extend({
                 return self.visibilityByFilter(d);
             })
             .attr("fill", function(d) {
-                return ns.color(ns.uniqueEventTypes.indexOf(d.doc_type) % ns.color.range().length);
+                var result;
+                if (d && d.traits && d.traits.outcome) {
+                    result = d.traits.outcome;
+
+                    // 0: green, 1: blue, 2: orange
+                    return result === 'success' ? ns.color(0) : result === 'pending' ? ns.color(1) : ns.color(2);
+                } else {
+                    return ns.color(2);
+                }
             })
             .on("mouseover", ns.tooltip.show)
             .on("mouseout", function() {
@@ -6533,10 +6538,6 @@ var EventTimelineView = GoldstoneBaseView.extend({
     render: function() {
         this.$el.html(this.template());
 
-        // commented out, as the settings are determined by the
-        // global lookback selector
-        // $('#modal-container-' + this.el.slice(1)).append(this.eventSettingModal());
-
         // append the modal that is triggered by
         // clicking the filter icon
         $('#modal-container-' + this.el.slice(1)).append(this.eventFilterModal());
@@ -6572,11 +6573,6 @@ var EventTimelineView = GoldstoneBaseView.extend({
         '<div id = "goldstone-event-panel" class="panel panel-primary">' +
         '<div class="panel-heading">' +
         '<h3 class="panel-title"><i class="fa fa-tasks"></i> <%= this.defaults.chartTitle %>' +
-
-        // cog icon
-        // '<i class="fa fa-cog pull-right" data-toggle="modal"' +
-        // 'data-target="#modal-settings-<%= this.el.slice(1) %>' +
-        // '"></i>' +
 
         // filter icon
         '<i class="fa fa-filter pull-right" data-toggle="modal"' +
@@ -6636,71 +6632,8 @@ var EventTimelineView = GoldstoneBaseView.extend({
         '</div>' +
         '</div>' +
         '</div>'
-    ),
-
-    eventSettingModal: _.template(
-        // event settings modal
-        // don't render if using global refresh/lookback
-        '<div class="modal fade" id="modal-settings-<%= this.el.slice(1) %>' +
-        '" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">' +
-        '<div class="modal-dialog">' +
-        '<div class="modal-content">' +
-        '<div class="modal-header">' +
-        '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>' +
-        '<h4 class="modal-title" id="myModalLabel">Chart Range Settings</h4>' +
-        '</div>' +
-        '<div class="modal-body">' +
-
-        // insert start/end form elements:
-
-        '<form class="form-horizontal" role="form">' +
-        '<div class="form-group">' +
-        '<label for="lookbackRange" class="col-sm-2 control-label">Lookback: </label>' +
-        '<div class="col-sm-5">' +
-        '<div class="input-group">' +
-        '<select class="form-control" id="lookbackRange">' +
-        '<option value="15">15 minutes</option>' +
-        '<option value="60" selected>1 hour</option>' +
-        '<option value="360">6 hours</option>' +
-        '<option value="1440">1 day</option>' +
-        '</select>' +
-        '</div>' +
-        '</div>' +
-        '</div>' +
-        '</form>' +
-
-        // end of new start/end elements
-
-        '<form class="form-horizontal" role="form">' +
-        '<div class="form-group">' +
-        '<label for="eventAutoRefresh" class="col-sm-2 control-label">Refresh: </label>' +
-        '<div class="col-sm-5">' +
-        '<div class="input-group">' +
-        '<span class="input-group-addon">' +
-        '<input type="checkbox" class="eventAutoRefresh" checked>' +
-        '</span>' +
-        '<select class="form-control" id="eventAutoRefreshInterval">' +
-        '<option value="5">5 seconds</option>' +
-        '<option value="15">15 seconds</option>' +
-        '<option value="30" selected>30 seconds</option>' +
-        '<option value="60">1 minute</option>' +
-        '<option value="300">5 minutes</option>' +
-        '</select>' +
-        '</div>' +
-        '</div>' +
-        '</div>' +
-        '</form>' +
-        '</div>' +
-        '<div class="modal-footer">' +
-        '<div class="form-group">' +
-        '<button type="button" id="eventSettingsUpdateButton-<%= this.el.slice(1) %>' +
-        '" class="btn btn-primary" data-dismiss="modal">Update</button>' +
-        '</div>' +
-        '</div>' +
-        '</div>' +
-        '</div>' +
-        '</div>'
     )
+
 });
 ;
 /**


### PR DESCRIPTION
Event timeline: hovering on bars brings new popup.

Bar color is now keyed to
* success (green)
* pending (blue)
* other (orange)

Improved animation of bars via d3 enter/update transition flow.

from:

<img width="440" alt="screen shot 2015-11-17 at 1 08 56 pm" src="https://cloud.githubusercontent.com/assets/5633015/11226289/d6b6e4f4-8d33-11e5-9b50-290999402bf9.png">

to:

<img width="564" alt="screen shot 2015-11-17 at 1 56 02 pm" src="https://cloud.githubusercontent.com/assets/5633015/11226291/d8a494e6-8d33-11e5-9dad-43341c850e1e.png">
