### PR TITLE
nova spawns should not return exception when no spawns have occurred.

### DIFF
--- a/goldstone/nova/serializers.py
+++ b/goldstone/nova/serializers.py
@@ -16,8 +16,7 @@ from goldstone.drfes.serializers import ReadOnlyElasticSerializer
 
 
 class SpawnsAggSerializer(ReadOnlyElasticSerializer):
-    """Custom serializer to manipulate the aggregation that comes back from
-    ES."""
+    """A serializer to manipulate the aggregation that comes back from ES."""
 
     DATEHIST_AGG_NAME = 'per_interval'
     SUCCESS_AGG_NAME = 'success'
@@ -26,11 +25,11 @@ class SpawnsAggSerializer(ReadOnlyElasticSerializer):
         """Create serialized representation of a single top-level aggregation.
 
         :param instance: the result from the Model.simple_agg call
-        :return:
 
         """
 
         datehist_agg_base = getattr(instance, self.DATEHIST_AGG_NAME, None)
+
         assert datehist_agg_base is not None, (
             "DATEHIST_AGG_NAME must exist in the instance passed to %s."
             % self.__class__.__name__

--- a/goldstone/nova/views.py
+++ b/goldstone/nova/views.py
@@ -317,8 +317,15 @@ class SpawnsAggView(DateHistogramAggView):
         model = SpawnsData
 
     def get(self, request):
+        from elasticsearch.exceptions import NotFoundError
 
-        search = self._get_search(request).query('term', event='finish')
+        try:
+            search = self._get_search(request).query('term', event='finish')
+        except NotFoundError:
+            # Elasticsearch has no nova spawns, so return zero results instead
+            # of an exception.
+            return Response([])
+
         search.aggs[self.AGG_NAME].bucket(
             self.SUCCESS_AGG_NAME, self.Meta.model.success_agg())
 


### PR DESCRIPTION
To test, delete all your docker containers and then do a bin/start_dev_env.sh.  After the server starts, log in to Goldstone and go to the "compute" metrics page.