### PR TITLE
Logviewer defined_search 

### DIFF
--- a/client/js/collections/logBrowserCollection.js
+++ b/client/js/collections/logBrowserCollection.js
@@ -63,7 +63,7 @@ var LogBrowserCollection = GoldstoneBaseCollection.extend({
     },
 
     addInterval: function() {
-        var n;
+        var computedInterval;
         var start;
         var end;
 
@@ -76,12 +76,12 @@ var LogBrowserCollection = GoldstoneBaseCollection.extend({
         }
 
         // interval ratio of 1/20th the time span in seconds.
-        n = ((end - start) / 20000);
+        computedInterval = ((end - start) / 20000);
         // ensure a minimum of 0.5second interval
-        n = Math.max(0.5, n);
+        computedInterval = Math.max(0.5, computedInterval);
         // round to 3 decimal places
-        n = Math.round(n * 1000) / 1000;
-        return '&interval=' + n + 's';
+        computedInterval = Math.round(computedInterval * 1000) / 1000;
+        return '&interval=' + computedInterval + 's';
     },
 
     addCustom: function(custom) {

--- a/client/js/views/logBrowserDataTableView.js
+++ b/client/js/views/logBrowserDataTableView.js
@@ -41,9 +41,30 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
         // from viz above
     },
 
+    predefinedSearchUrl: null,
+
+    predefinedSearch: function(uuid) {
+        var self = this;
+
+        // turn off refresh range as a signal to the user that refreshes
+        // will no longer be occuring without changing the lookback
+        // or refresh. setZoomed will block the action of the cached refresh
+        $('#global-refresh-range').val(-1);
+        this.trigger('setZoomed', true);
+
+        // the presence of a predefinedSearchUrl will take precidence
+        // when creating a fetch url in the ajax.beforeSend routine.
+        this.predefinedSearchUrl = '/compliance/defined_search/' + uuid[0] + '/results/';
+        oTable = $("#reports-result-table").DataTable();
+        oTable.ajax.reload();
+    },
 
     update: function() {
         var oTable;
+
+        // clear out the saved search url so next time the viz is
+        // triggered it will not return the previously saved url
+        this.predefinedSearchUrl = null;
 
         if ($.fn.dataTable.isDataTable("#reports-result-table")) {
             oTable = $("#reports-result-table").DataTable();
@@ -112,10 +133,9 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
 
                     var urlOrderingDirection = decodeURIComponent(settings.url).match(/order\[0\]\[dir\]=(asc|desc)/gi);
 
-                    // the url that will be fetched is now about to be
-                    // replaced with the urlGen'd url before adding on
-                    // the parsed components
-                    settings.url = self.collectionMixin.url + "&page_size=" + pageSize +
+                    // if a predefined search url has been set
+                    // use that instead of the generated url
+                    settings.url = (self.predefinedSearchUrl ? self.predefinedSearchUrl + '?' : self.collectionMixin.url + '&') + "page_size=" + pageSize +
                         "&page=" + computeStartPage;
 
                     // here begins the combiation of additional params
@@ -155,8 +175,6 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
                         // settings.url = settings.url + "&ordering=" +
                         //     ascDec + columnLabelHash[orderByColumn];
                     }
-
-
 
                 },
                 dataSrc: "results",

--- a/client/js/views/logBrowserDataTableView.js
+++ b/client/js/views/logBrowserDataTableView.js
@@ -54,9 +54,16 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
 
         // the presence of a predefinedSearchUrl will take precidence
         // when creating a fetch url in the ajax.beforeSend routine.
-        this.predefinedSearchUrl = '/compliance/defined_search/' + uuid[0] + '/results/';
+        this.predefinedSearchUrl = uuid;
         oTable = $("#reports-result-table").DataTable();
-        oTable.ajax.reload();
+        oTable.ajax.reload(function() {
+            setTimeout(function() {
+
+                // manually retrigger column auto adjust which was not firing
+                oTable.columns.adjust().draw();
+            }, 10);
+
+        });
     },
 
     update: function() {

--- a/client/js/views/logBrowserViz.js
+++ b/client/js/views/logBrowserViz.js
@@ -94,6 +94,12 @@ var LogBrowserViz = GoldstoneBaseView.extend({
     // will prevent updating when zoom is active
     isZoomed: false,
 
+    predefinedSearch: function(payload) {
+        this.collection.reset();
+        this.collection.add(payload);
+        this.update();
+    },
+
     setZoomed: function(bool) {
         this.isZoomed = bool;
         this.collection.isZoomed = bool;
@@ -123,12 +129,14 @@ var LogBrowserViz = GoldstoneBaseView.extend({
             self.showSpinner();
             self.setZoomed(false);
             self.constructUrl();
+            this.trigger('chartUpdate');
         });
 
         this.listenTo(this, 'refreshSelectorChanged', function() {
             self.showSpinner();
             self.setZoomed(false);
             self.constructUrl();
+            this.trigger('chartUpdate');
         });
 
         this.listenTo(this, 'lookbackIntervalReached', function() {
@@ -137,6 +145,7 @@ var LogBrowserViz = GoldstoneBaseView.extend({
             }
             this.showSpinner();
             this.constructUrl();
+            this.trigger('chartUpdate');
         });
 
     },
@@ -274,6 +283,7 @@ var LogBrowserViz = GoldstoneBaseView.extend({
         this.collection.zoomedEnd = Math.min(+new Date(), zoomedEnd);
 
         this.constructUrl();
+        this.trigger('chartUpdate');
         return;
     },
 
@@ -287,7 +297,6 @@ var LogBrowserViz = GoldstoneBaseView.extend({
 
         // this.collection.toJSON() returns the collection data
         var collectionDataPayload = this.collection.toJSON()[0];
-
         // we use only the 'data' for the construction of the chart
         var data = collectionDataPayload.aggregations.per_interval.buckets;
 
@@ -413,6 +422,10 @@ var LogBrowserViz = GoldstoneBaseView.extend({
             .domain(["EMERGENCY", "ALERT", "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG"])
             .range(self.colorArray.distinct.openStackSeverity8);
 
+        // clear viz
+        self.chart.selectAll('.component')
+            .remove();
+
         // If we didn't receive any valid files, append "No Data Returned" and halt
         if (this.checkReturnedDataSet(allthelogs) === false) {
             return;
@@ -462,9 +475,6 @@ var LogBrowserViz = GoldstoneBaseView.extend({
                 return self.sums(d);
             }))
         ]);
-
-        self.chart.selectAll('.component')
-            .remove();
 
         var component = self.chart.selectAll(".component")
             .data(components)
@@ -589,7 +599,7 @@ var LogBrowserViz = GoldstoneBaseView.extend({
             .duration(500)
             .call(self.yAxis.scale(self.y));
 
-        this.trigger('chartUpdate');
+        // this.trigger('chartUpdate');
     },
 
     template: _.template(

--- a/client/js/views/logSearchPageView.js
+++ b/client/js/views/logSearchPageView.js
@@ -85,7 +85,17 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
             if (goldstone.compliance.PredefinedSearchView) {
                 this.predefinedSearchModule = new goldstone.compliance.PredefinedSearchView({
                     className: 'compliance-predefined-search nav nav-pills',
-                    tagName: 'ul'
+                    tagName: 'ul',
+                    collection: new GoldstoneBaseCollection({
+                        skipFetch: true,
+                        urlBase: '',
+                        addRange: function() {
+                            return '?@timestamp__range={"gte":' + this.gte + ',"lte":' + this.epochNow + '}';
+                        },
+                        addInterval: function(interval) {
+                            return '&interval=' + interval + 's';
+                        },
+                    })
                 });
 
                 $('.compliance-predefined-search-container').html(this.predefinedSearchModule.el);
@@ -98,9 +108,13 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
 
             // subscribe logBrowserViz to click events on predefined
             // search dropdown to fetch results.
-            this.listenTo(this.predefinedSearchModule, 'clickedUuid', function(uuid) {
-                self.logBrowserTable.predefinedSearch(uuid[1]);
+            this.listenTo(this.predefinedSearchModule, 'clickedUuidViz', function(uuid) {
+                // self.logBrowserTable.predefinedSearch(uuid[1]);
                 self.logBrowserViz.predefinedSearch(uuid[0]);
+            });
+            this.listenTo(this.predefinedSearchModule, 'clickedUuidTable', function(uuid) {
+                self.logBrowserTable.predefinedSearch(uuid[1]);
+                // self.logBrowserViz.predefinedSearch(uuid[0]);
             });
         }
 

--- a/client/js/views/logSearchPageView.js
+++ b/client/js/views/logSearchPageView.js
@@ -60,7 +60,7 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
             specificHost: this.specificHost,
             urlBase: '/core/logs/',
             linkedCollection: this.logBrowserVizCollection
-        });    
+        });
 
         this.logBrowserTable = new LogBrowserDataTableView({
             chartTitle: goldstone.contextTranslate('Log Browser', 'logbrowserpage'),
@@ -76,12 +76,9 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
             this.setZoomed(trueFalse);
         });
 
-        // set up a chain of events between viz and table to uddate
-        // table when updating viz.
-        this.listenTo(this.logBrowserViz, 'chartUpdate', function() {
-            self.logBrowserTableCollection.filter = self.logBrowserViz.filter;
-            self.logBrowserTable.update();
-        });
+
+        this.viewsToStopListening = [this.logBrowserVizCollection, this.logBrowserViz, this.logBrowserTableCollection, this.logBrowserTable];
+
 
         // check for compliance addon and render predefined search bar if present
         if (goldstone.returnAddonPresent('compliance')) {
@@ -94,19 +91,25 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
                 $('.compliance-predefined-search-container').html(this.predefinedSearchModule.el);
             }
 
-            // subscribe tableCollection to click events on predefined
+            // stopListening to predefinedSearchModule upon close, if present
+            if (this.predefinedSearchModule !== undefined) {
+                this.viewsToStopListening.push(this.predefinedSearchModule);
+            }
+
+            // subscribe logBrowserViz to click events on predefined
             // search dropdown to fetch results.
-            this.logBrowserTable.listenTo(this.predefinedSearchModule, 'clickedUuid', function(uuid){
-                this.predefinedSearch(uuid);
+            this.listenTo(this.predefinedSearchModule, 'clickedUuid', function(uuid) {
+                self.logBrowserTable.predefinedSearch(uuid[1]);
+                self.logBrowserViz.predefinedSearch(uuid[0]);
             });
         }
 
-        this.viewsToStopListening = [this.logBrowserVizCollection, this.logBrowserViz, this.logBrowserTableCollection, this.logBrowserTable];
-
-        // stopListening to predefinedSearchModule upon close, if present
-        if (this.predefinedSearchModule !== undefined) {
-            this.viewsToStopListening.push(this.predefinedSearchModule);
-        }
+        // set up a chain of events between viz and table to uddate
+        // table when updating viz.
+        this.listenTo(this.logBrowserViz, 'chartUpdate', function() {
+            self.logBrowserTableCollection.filter = self.logBrowserViz.filter;
+            self.logBrowserTable.update();
+        });
 
     },
 

--- a/client/js/views/logSearchPageView.js
+++ b/client/js/views/logSearchPageView.js
@@ -70,6 +70,10 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
             width: $('#log-viewer-table').width()
         });
 
+        // initial rendering of logBrowserTable:
+        this.logBrowserTableCollection.filter = this.logBrowserViz.filter;
+        this.logBrowserTable.update();
+
         // set up listener between viz and table to setZoomed to 'true'
         // when user triggers a saved search
         this.logBrowserViz.listenTo(this.logBrowserTable, 'setZoomed', function(trueFalse) {

--- a/client/js/views/logSearchPageView.js
+++ b/client/js/views/logSearchPageView.js
@@ -70,6 +70,14 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
             width: $('#log-viewer-table').width()
         });
 
+        // set up listener between viz and table to setZoomed to 'true'
+        // when user triggers a saved search
+        this.logBrowserViz.listenTo(this.logBrowserTable, 'setZoomed', function(trueFalse) {
+            this.setZoomed(trueFalse);
+        });
+
+        // set up a chain of events between viz and table to uddate
+        // table when updating viz.
         this.listenTo(this.logBrowserViz, 'chartUpdate', function() {
             self.logBrowserTableCollection.filter = self.logBrowserViz.filter;
             self.logBrowserTable.update();
@@ -85,6 +93,12 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
 
                 $('.compliance-predefined-search-container').html(this.predefinedSearchModule.el);
             }
+
+            // subscribe tableCollection to click events on predefined
+            // search dropdown to fetch results.
+            this.logBrowserTable.listenTo(this.predefinedSearchModule, 'clickedUuid', function(uuid){
+                this.predefinedSearch(uuid);
+            });
         }
 
         this.viewsToStopListening = [this.logBrowserVizCollection, this.logBrowserViz, this.logBrowserTableCollection, this.logBrowserTable];

--- a/goldstone/core/views.py
+++ b/goldstone/core/views.py
@@ -494,7 +494,6 @@ class SavedSearchViewSet(ModelViewSet):
         # buckets go back to the start time.
         time_range_param = obj.timestamp_field + "__range"
         if time_range_param in request.query_params:
-            logger.info('query params[tr] = %s' % request.query_params[time_range_param])
             json = literal_eval(request.query_params[time_range_param])
             if 'gt' in json:
                 queryset.aggs.aggs['per_interval'].extended_bounds = {

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -7283,6 +7283,10 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
             width: $('#log-viewer-table').width()
         });
 
+        // initial rendering of logBrowserTable:
+        this.logBrowserTableCollection.filter = this.logBrowserViz.filter;
+        this.logBrowserTable.update();
+
         // set up listener between viz and table to setZoomed to 'true'
         // when user triggers a saved search
         this.logBrowserViz.listenTo(this.logBrowserTable, 'setZoomed', function(trueFalse) {

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -7298,7 +7298,17 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
             if (goldstone.compliance.PredefinedSearchView) {
                 this.predefinedSearchModule = new goldstone.compliance.PredefinedSearchView({
                     className: 'compliance-predefined-search nav nav-pills',
-                    tagName: 'ul'
+                    tagName: 'ul',
+                    collection: new GoldstoneBaseCollection({
+                        skipFetch: true,
+                        urlBase: '',
+                        addRange: function() {
+                            return '?@timestamp__range={"gte":' + this.gte + ',"lte":' + this.epochNow + '}';
+                        },
+                        addInterval: function(interval) {
+                            return '&interval=' + interval + 's';
+                        },
+                    })
                 });
 
                 $('.compliance-predefined-search-container').html(this.predefinedSearchModule.el);
@@ -7311,9 +7321,13 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
 
             // subscribe logBrowserViz to click events on predefined
             // search dropdown to fetch results.
-            this.listenTo(this.predefinedSearchModule, 'clickedUuid', function(uuid) {
-                self.logBrowserTable.predefinedSearch(uuid[1]);
+            this.listenTo(this.predefinedSearchModule, 'clickedUuidViz', function(uuid) {
+                // self.logBrowserTable.predefinedSearch(uuid[1]);
                 self.logBrowserViz.predefinedSearch(uuid[0]);
+            });
+            this.listenTo(this.predefinedSearchModule, 'clickedUuidTable', function(uuid) {
+                self.logBrowserTable.predefinedSearch(uuid[1]);
+                // self.logBrowserViz.predefinedSearch(uuid[0]);
             });
         }
 

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -3294,7 +3294,7 @@ var LogBrowserCollection = GoldstoneBaseCollection.extend({
     },
 
     addInterval: function() {
-        var n;
+        var computedInterval;
         var start;
         var end;
 
@@ -3307,12 +3307,12 @@ var LogBrowserCollection = GoldstoneBaseCollection.extend({
         }
 
         // interval ratio of 1/20th the time span in seconds.
-        n = ((end - start) / 20000);
+        computedInterval = ((end - start) / 20000);
         // ensure a minimum of 0.5second interval
-        n = Math.max(0.5, n);
+        computedInterval = Math.max(0.5, computedInterval);
         // round to 3 decimal places
-        n = Math.round(n * 1000) / 1000;
-        return '&interval=' + n + 's';
+        computedInterval = Math.round(computedInterval * 1000) / 1000;
+        return '&interval=' + computedInterval + 's';
     },
 
     addCustom: function(custom) {
@@ -6387,9 +6387,16 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
 
         // the presence of a predefinedSearchUrl will take precidence
         // when creating a fetch url in the ajax.beforeSend routine.
-        this.predefinedSearchUrl = '/compliance/defined_search/' + uuid[0] + '/results/';
+        this.predefinedSearchUrl = uuid;
         oTable = $("#reports-result-table").DataTable();
-        oTable.ajax.reload();
+        oTable.ajax.reload(function() {
+            setTimeout(function() {
+
+                // manually retrigger column auto adjust which was not firing
+                oTable.columns.adjust().draw();
+            }, 10);
+
+        });
     },
 
     update: function() {
@@ -6649,6 +6656,12 @@ var LogBrowserViz = GoldstoneBaseView.extend({
     // will prevent updating when zoom is active
     isZoomed: false,
 
+    predefinedSearch: function(payload) {
+        this.collection.reset();
+        this.collection.add(payload);
+        this.update();
+    },
+
     setZoomed: function(bool) {
         this.isZoomed = bool;
         this.collection.isZoomed = bool;
@@ -6678,12 +6691,14 @@ var LogBrowserViz = GoldstoneBaseView.extend({
             self.showSpinner();
             self.setZoomed(false);
             self.constructUrl();
+            this.trigger('chartUpdate');
         });
 
         this.listenTo(this, 'refreshSelectorChanged', function() {
             self.showSpinner();
             self.setZoomed(false);
             self.constructUrl();
+            this.trigger('chartUpdate');
         });
 
         this.listenTo(this, 'lookbackIntervalReached', function() {
@@ -6692,6 +6707,7 @@ var LogBrowserViz = GoldstoneBaseView.extend({
             }
             this.showSpinner();
             this.constructUrl();
+            this.trigger('chartUpdate');
         });
 
     },
@@ -6829,6 +6845,7 @@ var LogBrowserViz = GoldstoneBaseView.extend({
         this.collection.zoomedEnd = Math.min(+new Date(), zoomedEnd);
 
         this.constructUrl();
+        this.trigger('chartUpdate');
         return;
     },
 
@@ -6842,7 +6859,6 @@ var LogBrowserViz = GoldstoneBaseView.extend({
 
         // this.collection.toJSON() returns the collection data
         var collectionDataPayload = this.collection.toJSON()[0];
-
         // we use only the 'data' for the construction of the chart
         var data = collectionDataPayload.aggregations.per_interval.buckets;
 
@@ -6968,6 +6984,10 @@ var LogBrowserViz = GoldstoneBaseView.extend({
             .domain(["EMERGENCY", "ALERT", "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG"])
             .range(self.colorArray.distinct.openStackSeverity8);
 
+        // clear viz
+        self.chart.selectAll('.component')
+            .remove();
+
         // If we didn't receive any valid files, append "No Data Returned" and halt
         if (this.checkReturnedDataSet(allthelogs) === false) {
             return;
@@ -7017,9 +7037,6 @@ var LogBrowserViz = GoldstoneBaseView.extend({
                 return self.sums(d);
             }))
         ]);
-
-        self.chart.selectAll('.component')
-            .remove();
 
         var component = self.chart.selectAll(".component")
             .data(components)
@@ -7144,7 +7161,7 @@ var LogBrowserViz = GoldstoneBaseView.extend({
             .duration(500)
             .call(self.yAxis.scale(self.y));
 
-        this.trigger('chartUpdate');
+        // this.trigger('chartUpdate');
     },
 
     template: _.template(
@@ -7256,7 +7273,7 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
             specificHost: this.specificHost,
             urlBase: '/core/logs/',
             linkedCollection: this.logBrowserVizCollection
-        });    
+        });
 
         this.logBrowserTable = new LogBrowserDataTableView({
             chartTitle: goldstone.contextTranslate('Log Browser', 'logbrowserpage'),
@@ -7266,10 +7283,15 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
             width: $('#log-viewer-table').width()
         });
 
-        this.listenTo(this.logBrowserViz, 'chartUpdate', function() {
-            self.logBrowserTableCollection.filter = self.logBrowserViz.filter;
-            self.logBrowserTable.update();
+        // set up listener between viz and table to setZoomed to 'true'
+        // when user triggers a saved search
+        this.logBrowserViz.listenTo(this.logBrowserTable, 'setZoomed', function(trueFalse) {
+            this.setZoomed(trueFalse);
         });
+
+
+        this.viewsToStopListening = [this.logBrowserVizCollection, this.logBrowserViz, this.logBrowserTableCollection, this.logBrowserTable];
+
 
         // check for compliance addon and render predefined search bar if present
         if (goldstone.returnAddonPresent('compliance')) {
@@ -7282,19 +7304,25 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
                 $('.compliance-predefined-search-container').html(this.predefinedSearchModule.el);
             }
 
-            // subscribe tableCollection to click events on predefined
+            // stopListening to predefinedSearchModule upon close, if present
+            if (this.predefinedSearchModule !== undefined) {
+                this.viewsToStopListening.push(this.predefinedSearchModule);
+            }
+
+            // subscribe logBrowserViz to click events on predefined
             // search dropdown to fetch results.
-            this.logBrowserTable.listenTo(this.predefinedSearchModule, 'clickedUuid', function(uuid){
-                this.predefinedSearch(uuid);
+            this.listenTo(this.predefinedSearchModule, 'clickedUuid', function(uuid) {
+                self.logBrowserTable.predefinedSearch(uuid[1]);
+                self.logBrowserViz.predefinedSearch(uuid[0]);
             });
         }
 
-        this.viewsToStopListening = [this.logBrowserVizCollection, this.logBrowserViz, this.logBrowserTableCollection, this.logBrowserTable];
-
-        // stopListening to predefinedSearchModule upon close, if present
-        if (this.predefinedSearchModule !== undefined) {
-            this.viewsToStopListening.push(this.predefinedSearchModule);
-        }
+        // set up a chain of events between viz and table to uddate
+        // table when updating viz.
+        this.listenTo(this.logBrowserViz, 'chartUpdate', function() {
+            self.logBrowserTableCollection.filter = self.logBrowserViz.filter;
+            self.logBrowserTable.update();
+        });
 
     },
 
@@ -8792,14 +8820,6 @@ var NodeReportView = GoldstoneBasePageView.extend({
             width: $('#log-viewer-table').width()
         });
 
-        // set up listener between viz and table to setZoomed to 'true'
-        // when user triggers a saved search
-        this.logBrowserViz.listenTo(this.logBrowserTable, 'setZoomed', function(trueFalse) {
-            this.setZoomed(trueFalse);
-        });
-
-        // set up a chain of events between viz and table to uddate
-        // table when updating viz.
         this.listenTo(this.logBrowserViz, 'chartUpdate', function() {
             self.logBrowserTableCollection.filter = self.logBrowserViz.filter;
             self.logBrowserTable.update();


### PR DESCRIPTION
This is in MVP state for friday deadline.
Changes needed are ticketed on #246 .

Goes along with submodule PR:
https://github.com/Solinea/goldstone-compliance/pull/39

MVP of drop-down defined_search functionality.
You will get a viz and dataTable results for each selection from the dropdown.
You can filter by event type on the viz, but for defined_searches, will not get a corresponding change in the table.
You can not zoom into defined_searches.

All original page functionality should be preserved.
