### PR TITLE
Docker compose version

### DIFF
--- a/bin/semver.sh
+++ b/bin/semver.sh
@@ -14,7 +14,7 @@
 #       dev version from feature : 2.2.0-SNAPSHOT.35.g88e2ebb.versioning
 
 EPOCH=$(date +%s)
-GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD| sed -e 's/-/./g')
 VERSION=$(git describe --tags --match [0-9].[0-9].[0-9]  --always | cut -f1 -d'-')
 if [[ $GIT_BRANCH == 'master' ]] ; then
   RELEASE=$(git describe --match [0-9].[0-9].[0-9] --tags | cut -f2 -d'-')

--- a/rpm_packaging/before-install.sh
+++ b/rpm_packaging/before-install.sh
@@ -4,7 +4,7 @@
 
 # install docker-compose
 export GS_PATH="/opt"
-export DC_URL="https://github.com/docker/compose/releases/download/1.5.0/docker-compose-"
+export DC_URL="https://github.com/docker/compose/releases/download/1.5.2/docker-compose-"
 
 if [[ $# == 1 && $1 == 1 ]] ; then
     echo "Installing docker-compose to %{prefix}/goldstone/bin"

--- a/rpm_packaging/before-install.sh
+++ b/rpm_packaging/before-install.sh
@@ -4,7 +4,7 @@
 
 # install docker-compose
 export GS_PATH="/opt"
-export DC_URL="https://github.com/docker/compose/releases/download/1.4.0/docker-compose-"
+export DC_URL="https://github.com/docker/compose/releases/download/1.5.0/docker-compose-"
 
 if [[ $# == 1 && $1 == 1 ]] ; then
     echo "Installing docker-compose to %{prefix}/goldstone/bin"
@@ -12,5 +12,4 @@ if [[ $# == 1 && $1 == 1 ]] ; then
     /usr/bin/curl -# -o $GS_PATH/goldstone/bin/docker-compose --create-dirs -L \
         $DC_URL`uname -s`-`uname -m` \
         && chmod +x $GS_PATH/goldstone/bin/docker-compose
-
 fi


### PR DESCRIPTION
Upgrade `docker-compose` version installed by RPM from 1.4 (Aug 2015) to 1.5.2 (current), which fixes an installation problem on CentOS. Also fixes bug in `semver.sh` where the branch name contains dashes, which are illegal in RPM names after version number and build.