### PR TITLE
clean up pagination problems with affecting OSS version

### DIFF
--- a/goldstone/cinder/views.py
+++ b/goldstone/cinder/views.py
@@ -1,11 +1,11 @@
 """Cinder views."""
-# Copyright 2014 - 2015 Solinea, Inc.
+# Copyright 2015 Solinea, Inc.
 #
-# Licensed under the Solinea Software License Agreement (goldstone),
-# Version 1.0 (the "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at:
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#     http://www.solinea.com/goldstone/LICENSE.pdf
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/goldstone/core/pagination.py
+++ b/goldstone/core/pagination.py
@@ -1,0 +1,22 @@
+"""Default pagination."""
+# Copyright 2015 Solinea, Inc.
+#
+# Licensed under the Solinea Software License Agreement (goldstone),
+# Version 1.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#     http://www.solinea.com/goldstone/LICENSE.pdf
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from rest_framework.pagination import PageNumberPagination
+
+
+class Pagination(PageNumberPagination):
+    """Perform the standard pagination, and allow the caller to specify the
+    page size."""
+
+    page_size_query_param = "page_size"

--- a/goldstone/core/tasks.py
+++ b/goldstone/core/tasks.py
@@ -1,11 +1,11 @@
 """Core tasks."""
-# Copyright 2014 - 2015 Solinea, Inc.
+# Copyright 2015 Solinea, Inc.
 #
-# Licensed under the Solinea Software License Agreement (goldstone),
-# Version 1.0 (the "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at:
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#     http://www.solinea.com/goldstone/LICENSE.pdf
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/goldstone/core/templatetags/__init__.py
+++ b/goldstone/core/templatetags/__init__.py
@@ -1,11 +1,11 @@
 """Core template tags."""
-# Copyright 2014 - 2015 Solinea, Inc.
+# Copyright 2015 Solinea, Inc.
 #
-# Licensed under the Solinea Software License Agreement (goldstone),
-# Version 1.0 (the "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at:
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#     http://www.solinea.com/goldstone/LICENSE.pdf
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/goldstone/core/templatetags/custom_filters.py
+++ b/goldstone/core/templatetags/custom_filters.py
@@ -1,11 +1,11 @@
 """Core template tags for Django templates."""
-# Copyright 2014 - 2015 Solinea, Inc.
+# Copyright 2015 Solinea, Inc.
 #
-# Licensed under the Solinea Software License Agreement (goldstone),
-# Version 1.0 (the "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at:
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#     http://www.solinea.com/goldstone/LICENSE.pdf
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/goldstone/core/views.py
+++ b/goldstone/core/views.py
@@ -22,7 +22,6 @@ from rest_framework.response import Response
 from rest_framework.status import HTTP_404_NOT_FOUND, HTTP_200_OK, \
     HTTP_400_BAD_REQUEST
 from rest_framework.viewsets import ModelViewSet
-from goldstone.core.pagination import Pagination
 from goldstone.core.serializers import SavedSearchSerializer
 from goldstone.drfes.filters import ElasticFilter
 from goldstone.drfes.serializers import ElasticResponseSerializer
@@ -434,7 +433,6 @@ class SavedSearchFilter(ElasticFilter):
 class SavedSearchViewSet(ModelViewSet):
     """Provide the /defined_search/ endpoints."""
 
-    pagination_class = Pagination
     permission_classes = (IsAuthenticated, )
     serializer_class = SavedSearchSerializer
 

--- a/goldstone/core/views.py
+++ b/goldstone/core/views.py
@@ -22,7 +22,7 @@ from rest_framework.response import Response
 from rest_framework.status import HTTP_404_NOT_FOUND, HTTP_200_OK, \
     HTTP_400_BAD_REQUEST
 from rest_framework.viewsets import ModelViewSet
-from goldstone.compliance.pagination import Pagination
+from goldstone.core.pagination import Pagination
 from goldstone.core.serializers import SavedSearchSerializer
 from goldstone.drfes.filters import ElasticFilter
 from goldstone.drfes.serializers import ElasticResponseSerializer

--- a/goldstone/drfes/pagination.py
+++ b/goldstone/drfes/pagination.py
@@ -25,9 +25,6 @@ logger = logging.getLogger(__name__)
 
 class ElasticPageNumberPagination(pagination.PageNumberPagination):
 
-    # Allow the API call to specify a custom page size.
-    page_size_query_param = "page_size"
-
     def paginate_queryset(self, queryset, request, view=None):
         """Paginate a queryset if required, either returning a page object, or
         `None` if pagination is not configured for this view."""

--- a/goldstone/drfes/pagination.py
+++ b/goldstone/drfes/pagination.py
@@ -25,6 +25,8 @@ logger = logging.getLogger(__name__)
 
 class ElasticPageNumberPagination(pagination.PageNumberPagination):
 
+    page_size_query_param = "page_size"
+    
     def paginate_queryset(self, queryset, request, view=None):
         """Paginate a queryset if required, either returning a page object, or
         `None` if pagination is not configured for this view."""

--- a/goldstone/settings/base.py
+++ b/goldstone/settings/base.py
@@ -278,9 +278,8 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',
                                 'rest_framework.filters.OrderingFilter', ),
     'DEFAULT_PAGINATION_CLASS':
-        'rest_framework.pagination.PageNumberPagination',
-    'PAGINATE_BY': 10,
-    'PAGE_SIZE': 'page_size',
+        'goldstone.core.pagination.Pagination',
+    'PAGE_SIZE': 10,
     'EXCEPTION_HANDLER': 'goldstone.core.utils.custom_exception_handler'
 }
 

--- a/goldstone/settings/base.py
+++ b/goldstone/settings/base.py
@@ -277,8 +277,10 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',
                                 'rest_framework.filters.OrderingFilter', ),
+    'DEFAULT_PAGINATION_CLASS':
+        'rest_framework.pagination.PageNumberPagination',
     'PAGINATE_BY': 10,
-    'PAGINATE_BY_PARAM': 'page_size',
+    'PAGE_SIZE': 'page_size',
     'EXCEPTION_HANDLER': 'goldstone.core.utils.custom_exception_handler'
 }
 

--- a/test/integration/serviceStatusView_integrationTests.js
+++ b/test/integration/serviceStatusView_integrationTests.js
@@ -1,18 +1,18 @@
 /**
  * Copyright 2015 Solinea, Inc.
  *
- * Licensed under the Solinea Software License Agreement (goldstone),
- * Version 1.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.solinea.com/goldstone/LICENSE.pdf
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 /*global sinon, todo, chai, describe, it, calledOnce*/
 //integration tests


### PR DESCRIPTION
Addresses two pagination issues:
1) dependency from core to compliance for a pagination class removed
2) cleanup of DRF settings to use a default paginator and expression of query param for page_size

To be merged into the docker-builds branch. Has been tested to work in OSS RPM deployment.

closes: #259