### PR TITLE
set ceilometer metric data time_to_live to 1 week

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -19,7 +19,7 @@ gsappdev:
   env_file: ./docker/config/goldstone-dev.env
   volumes:
     - .:/home/app
-    - ./docker/goldstone-app/config:/home/app/config
+    - ./docker/goldstone-base/config:/home/app/config
   ports:
     - "8000:8000"
   links:

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -15,7 +15,7 @@
 
 # Database Container
 gsdb:
-  image: solinea/goldstone-db:0.8.3
+  image: solinea/goldstone-db:0.8.4-SNAPSHOT
   env_file: ./config/goldstone-test.env
   volumes_from:
     - gsdbdvc
@@ -24,14 +24,14 @@ gsdb:
 
 # Database Data Volume Container
 gsdbdvc:
-  image: solinea/goldstone-db:0.8.3
+  image: solinea/goldstone-db:0.8.4-SNAPSHOT
   entrypoint: /bin/true
   volumes:
     - /var/lib/postgresql/data
 
 # Logstash Container
 gslog:
-  image: solinea/goldstone-log:0.8.3
+  image: solinea/goldstone-log:0.8.4-SNAPSHOT
   ports:
     - "5514:5514"
     - "5515:5515"
@@ -41,13 +41,13 @@ gslog:
 
 # Elasticsearch Container
 gssearch:
-  image: solinea/goldstone-search:0.8.3
+  image: solinea/goldstone-search:0.8.4-SNAPSHOT
   ports:
     - "9200:9200"
     - "9300:9300"
 
 # Celery Task Queue Container
 gstaskq:
-  image: solinea/goldstone-task-queue:0.8.3
+  image: solinea/goldstone-task-queue:0.8.4-SNAPSHOT
   ports:
     - "6379:6379"

--- a/docker/docker-compose-enterprise.yml
+++ b/docker/docker-compose-enterprise.yml
@@ -15,7 +15,7 @@
 
 # Goldstone Proxy & Static
 gsweb:
-  image: solinea/goldstone-web:0.8.3
+  image: solinea/goldstone-web:0.8.4-SNAPSHOT
   ports:
     - "8888:8888"
   links:
@@ -27,7 +27,7 @@ gsweb:
 
 # Goldstone Server Container
 gsapp:
-  image: gs-docker-ent.bintray.io/goldstone-app-e:0.8.3
+  image: gs-docker-ent.bintray.io/goldstone-app-e:0.8.4-SNAPSHOT
   env_file: ./config/goldstone-prod.env
   ports:
     - "8000:8000"
@@ -42,7 +42,7 @@ gsapp:
 
 # Database Container
 gsdb:
-  image: solinea/goldstone-db:0.8.3
+  image: solinea/goldstone-db:0.8.4-SNAPSHOT
   env_file: ./config/goldstone-prod.env
   volumes_from:
     - gsdbdvc
@@ -55,7 +55,7 @@ gsdb:
 
 # Database Data Volume Container
 gsdbdvc:
-  image: solinea/goldstone-db:0.8.3
+  image: solinea/goldstone-db:0.8.4-SNAPSHOT
   entrypoint: /bin/true
   volumes:
     - /var/lib/postgresql/data
@@ -66,7 +66,7 @@ gsdbdvc:
 
 # Logstash Container
 gslog:
-  image: solinea/goldstone-log:0.8.3
+  image: solinea/goldstone-log:0.8.4-SNAPSHOT
   ports:
     - "5514:5514"
     - "5515:5515"
@@ -80,7 +80,7 @@ gslog:
 
 # Elasticsearch Container
 gssearch:
-  image: solinea/goldstone-search:0.8.3
+  image: solinea/goldstone-search:0.8.4-SNAPSHOT
   ports:
     - "9200:9200"
     - "9300:9300"
@@ -91,7 +91,7 @@ gssearch:
 
 # Celery Task Queue Container
 gstaskq:
-  image: solinea/goldstone-task-queue:0.8.3
+  image: solinea/goldstone-task-queue:0.8.4-SNAPSHOT
   ports:
     - "6379:6379"
   log_driver: "syslog"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@
 
 # Goldstone Proxy & Static
 gsweb:
-  image: solinea/goldstone-web:0.8.3
+  image: solinea/goldstone-web:0.8.4-SNAPSHOT
   ports:
     - "8888:8888"
   links:
@@ -27,7 +27,7 @@ gsweb:
 
 # Goldstone Server Container
 gsapp:
-  image: solinea/goldstone-app:0.8.3
+  image: solinea/goldstone-app:0.8.4-SNAPSHOT
   env_file: ./config/goldstone-prod.env
   ports:
     - "8000:8000"
@@ -42,7 +42,7 @@ gsapp:
 
 # Database Container
 gsdb:
-  image: solinea/goldstone-db:0.8.3
+  image: solinea/goldstone-db:0.8.4-SNAPSHOT
   env_file: ./config/goldstone-prod.env
   volumes_from:
     - gsdbdvc
@@ -55,7 +55,7 @@ gsdb:
 
 # Database Data Volume Container
 gsdbdvc:
-  image: solinea/goldstone-db:0.8.3
+  image: solinea/goldstone-db:0.8.4-SNAPSHOT
   entrypoint: /bin/true
   volumes:
     - /var/lib/postgresql/data
@@ -66,7 +66,7 @@ gsdbdvc:
 
 # Logstash Container
 gslog:
-  image: solinea/goldstone-log:0.8.3
+  image: solinea/goldstone-log:0.8.4-SNAPSHOT
   ports:
     - "5514:5514"
     - "5515:5515"
@@ -80,7 +80,7 @@ gslog:
 
 # Elasticsearch Container
 gssearch:
-  image: solinea/goldstone-search:0.8.3
+  image: solinea/goldstone-search:0.8.4-SNAPSHOT
   ports:
     - "9200:9200"
     - "9300:9300"
@@ -91,7 +91,7 @@ gssearch:
 
 # Celery Task Queue Container
 gstaskq:
-  image: solinea/goldstone-task-queue:0.8.3
+  image: solinea/goldstone-task-queue:0.8.4-SNAPSHOT
   ports:
     - "6379:6379"
   log_driver: "syslog"

--- a/docker/goldstone-app-e/Dockerfile
+++ b/docker/goldstone-app-e/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM solinea/goldstone-base:0.8.3
+FROM solinea/goldstone-base:0.8.4-SNAPSHOT
 
 MAINTAINER Luke Heidecke <luke@solinea.com>
 

--- a/docker/goldstone-app/Dockerfile
+++ b/docker/goldstone-app/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM solinea/goldstone-base:0.8.3
+FROM solinea/goldstone-base:0.8.4-SNAPSHOT
 
 MAINTAINER Luke Heidecke <luke@solinea.com>
 

--- a/goldstone/templates/base.html
+++ b/goldstone/templates/base.html
@@ -182,7 +182,7 @@ limitations under the License.
                     <!-- <div class="container"> -->
 
                     <div class="row">
-                        <span class="version">Version: 0.8.3</span>
+                        <span class="version">Version: 0.8.4-SNAPSHOT</span>
 
                         <span class="copyright"><strong><span class="i18n" data-i18n="Copyright">Copyright</span> 2014-2016</strong> <a href="http://www.solinea.com/">Solinea, Inc.</a></span>
 

--- a/goldstone/templates/login.html
+++ b/goldstone/templates/login.html
@@ -68,7 +68,7 @@ limitations under the License.
                 <div class="container">
 
                     <div class="row">
-                        <span class="version">Version: 0.8.3</span>
+                        <span class="version">Version: 0.8.4-SNAPSHOT</span>
 
                         <span class="copyright"><strong>Copyright 2014-2016</strong>
                          <a style="color:#fff" href="http://www.solinea.com">Solinea, Inc.</a></span>

--- a/post_install.py
+++ b/post_install.py
@@ -895,6 +895,11 @@ def _configure_ceilometer(backup_postfix, goldstone_addr, restart='yes',
                 "parameter": "event_connection",
                 "value": "es://%s:9200" % goldstone_addr
             },
+            {
+                "section": "database",
+                "parameter": "time_to_live",
+                "value": "604800"                # one week
+            },
         ]
     }
 


### PR DESCRIPTION
also fixes th goldstone-app config mountpoint in the developer docker-compose file and bumps the images and template versions to 0.8.4-SNAPSHOT.

To tests:
* pull the branch
* docker rm -f $(docker ps -qa)
* docker rmi -f goldstoneserver_gsappdev_1 goldstoneserver_gsdb_1
* bin/start_dev_env.sh
* docker exec -it goldstoneserver_gsappdev_1 bash

Now in the app container, run:

* fab -f post_install.py configure_stack -H 172.24.4.100
* answer yes to the first two questions
* answer 172.24.4.1 to the question about IP addresses
* use 'solinea' for the password

Verify by:
* ssh root@172.24.4.100
* password solinea
* grep time_to_live /etc/ceilometer.conf (should see value of 1 week in seconds)

closes: #172 