### PR TITLE
added state tracking files for migration and fixture loading

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -15,7 +15,7 @@
 
 # Database Container
 gsdb:
-  image: solinea/goldstone-db:0.8.3
+  image: solinea/goldstone-db:0.8.4-SNAPSHOT
   env_file: ./config/goldstone-test.env
   volumes_from:
     - gsdbdvc
@@ -24,14 +24,14 @@ gsdb:
 
 # Database Data Volume Container
 gsdbdvc:
-  image: solinea/goldstone-db:0.8.3
+  image: solinea/goldstone-db:0.8.4-SNAPSHOT
   entrypoint: /bin/true
   volumes:
     - /var/lib/postgresql/data
 
 # Logstash Container
 gslog:
-  image: solinea/goldstone-log:0.8.3
+  image: solinea/goldstone-log:0.8.4-SNAPSHOT
   ports:
     - "5514:5514"
     - "5515:5515"
@@ -41,13 +41,13 @@ gslog:
 
 # Elasticsearch Container
 gssearch:
-  image: solinea/goldstone-search:0.8.3
+  image: solinea/goldstone-search:0.8.4-SNAPSHOT
   ports:
     - "9200:9200"
     - "9300:9300"
 
 # Celery Task Queue Container
 gstaskq:
-  image: solinea/goldstone-task-queue:0.8.3
+  image: solinea/goldstone-task-queue:0.8.4-SNAPSHOT
   ports:
     - "6379:6379"

--- a/docker/docker-compose-enterprise.yml
+++ b/docker/docker-compose-enterprise.yml
@@ -15,7 +15,7 @@
 
 # Goldstone Proxy & Static
 gsweb:
-  image: solinea/goldstone-web:0.8.3
+  image: solinea/goldstone-web:0.8.4-SNAPSHOT
   ports:
     - "8888:8888"
   links:
@@ -27,7 +27,7 @@ gsweb:
 
 # Goldstone Server Container
 gsapp:
-  image: gs-docker-ent.bintray.io/goldstone-app-e:0.8.3
+  image: gs-docker-ent.bintray.io/goldstone-app-e:0.8.4-SNAPSHOT
   env_file: ./config/goldstone-prod.env
   ports:
     - "8000:8000"
@@ -42,7 +42,7 @@ gsapp:
 
 # Database Container
 gsdb:
-  image: solinea/goldstone-db:0.8.3
+  image: solinea/goldstone-db:0.8.4-SNAPSHOT
   env_file: ./config/goldstone-prod.env
   volumes_from:
     - gsdbdvc
@@ -55,7 +55,7 @@ gsdb:
 
 # Database Data Volume Container
 gsdbdvc:
-  image: solinea/goldstone-db:0.8.3
+  image: solinea/goldstone-db:0.8.4-SNAPSHOT
   entrypoint: /bin/true
   volumes:
     - /var/lib/postgresql/data
@@ -66,7 +66,7 @@ gsdbdvc:
 
 # Logstash Container
 gslog:
-  image: solinea/goldstone-log:0.8.3
+  image: solinea/goldstone-log:0.8.4-SNAPSHOT
   ports:
     - "5514:5514"
     - "5515:5515"
@@ -80,7 +80,7 @@ gslog:
 
 # Elasticsearch Container
 gssearch:
-  image: solinea/goldstone-search:0.8.3
+  image: solinea/goldstone-search:0.8.4-SNAPSHOT
   ports:
     - "9200:9200"
     - "9300:9300"
@@ -91,7 +91,7 @@ gssearch:
 
 # Celery Task Queue Container
 gstaskq:
-  image: solinea/goldstone-task-queue:0.8.3
+  image: solinea/goldstone-task-queue:0.8.4-SNAPSHOT
   ports:
     - "6379:6379"
   log_driver: "syslog"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@
 
 # Goldstone Proxy & Static
 gsweb:
-  image: solinea/goldstone-web:0.8.3
+  image: solinea/goldstone-web:0.8.4-SNAPSHOT
   ports:
     - "8888:8888"
   links:
@@ -27,7 +27,7 @@ gsweb:
 
 # Goldstone Server Container
 gsapp:
-  image: solinea/goldstone-app:0.8.3
+  image: solinea/goldstone-app:0.8.4-SNAPSHOT
   env_file: ./config/goldstone-prod.env
   ports:
     - "8000:8000"
@@ -42,7 +42,7 @@ gsapp:
 
 # Database Container
 gsdb:
-  image: solinea/goldstone-db:0.8.3
+  image: solinea/goldstone-db:0.8.4-SNAPSHOT
   env_file: ./config/goldstone-prod.env
   volumes_from:
     - gsdbdvc
@@ -55,7 +55,7 @@ gsdb:
 
 # Database Data Volume Container
 gsdbdvc:
-  image: solinea/goldstone-db:0.8.3
+  image: solinea/goldstone-db:0.8.4-SNAPSHOT
   entrypoint: /bin/true
   volumes:
     - /var/lib/postgresql/data
@@ -66,7 +66,7 @@ gsdbdvc:
 
 # Logstash Container
 gslog:
-  image: solinea/goldstone-log:0.8.3
+  image: solinea/goldstone-log:0.8.4-SNAPSHOT
   ports:
     - "5514:5514"
     - "5515:5515"
@@ -80,7 +80,7 @@ gslog:
 
 # Elasticsearch Container
 gssearch:
-  image: solinea/goldstone-search:0.8.3
+  image: solinea/goldstone-search:0.8.4-SNAPSHOT
   ports:
     - "9200:9200"
     - "9300:9300"
@@ -91,7 +91,7 @@ gssearch:
 
 # Celery Task Queue Container
 gstaskq:
-  image: solinea/goldstone-task-queue:0.8.3
+  image: solinea/goldstone-task-queue:0.8.4-SNAPSHOT
   ports:
     - "6379:6379"
   log_driver: "syslog"

--- a/docker/goldstone-app-e/Dockerfile
+++ b/docker/goldstone-app-e/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM solinea/goldstone-base:0.8.3
+FROM solinea/goldstone-base:0.8.4-SNAPSHOT
 
 MAINTAINER Luke Heidecke <luke@solinea.com>
 

--- a/docker/goldstone-app/Dockerfile
+++ b/docker/goldstone-app/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM solinea/goldstone-base:0.8.3
+FROM solinea/goldstone-base:0.8.4-SNAPSHOT
 
 MAINTAINER Luke Heidecke <luke@solinea.com>
 

--- a/docker/goldstone-base/docker-entrypoint.sh
+++ b/docker/goldstone-base/docker-entrypoint.sh
@@ -39,8 +39,15 @@ if [[ $status == "DOWN" ]] ; then
     exit 1
 fi
 
-python manage.py migrate --noinput  # Apply database migrations
-python manage.py loaddata $(find goldstone -regex '.*/fixtures/.*' | xargs)
+if [ ! -f /var/tmp/goldstone-migrated ] ; then
+    python manage.py migrate --noinput  # Apply database migrations
+    touch /var/tmp/goldstone-migrated
+fi
+
+if [ ! -f /var/tmp/goldstone-fixtured ] ; then
+    python manage.py loaddata $(find goldstone -regex '.*/fixtures/.*' | xargs)
+    touch /var/tmp/goldstone-fixtured
+fi
 
 # gather up the static files at container start if this is a dev environment
 if [[ $GS_DEV_ENV == "true" ]] ; then

--- a/goldstone/templates/base.html
+++ b/goldstone/templates/base.html
@@ -182,7 +182,7 @@ limitations under the License.
                     <!-- <div class="container"> -->
 
                     <div class="row">
-                        <span class="version">Version: 0.8.3</span>
+                        <span class="version">Version: 0.8.4-SNAPSHOT</span>
 
                         <span class="copyright"><strong><span class="i18n" data-i18n="Copyright">Copyright</span> 2014-2016</strong> <a href="http://www.solinea.com/">Solinea, Inc.</a></span>
 

--- a/goldstone/templates/login.html
+++ b/goldstone/templates/login.html
@@ -68,7 +68,7 @@ limitations under the License.
                 <div class="container">
 
                     <div class="row">
-                        <span class="version">Version: 0.8.3</span>
+                        <span class="version">Version: 0.8.4-SNAPSHOT</span>
 
                         <span class="copyright"><strong>Copyright 2014-2016</strong>
                          <a style="color:#fff" href="http://www.solinea.com">Solinea, Inc.</a></span>


### PR DESCRIPTION
migrations and fixtures should only occur the first time the container is started.  To test, drop your containers, delete your app and db images, and if you happen to have an 0.8.4-SNAPSHOT version of goldstone-base, drop that too. 

Then start the dev environment.  The first time, you should see output from migrate and loaddata.  If you log in to the app container, you will see two files in /var/tmp that are used as conditional checks.

Stop the dev env, then start again, and you should not see any messages related to migration and fixture loading.