### PR TITLE
Log Browser triage: filter/search/zoom/lookback/savedSearches all implemented.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -97,7 +97,7 @@ module.exports = function(grunt) {
             },
             // Single-run configuration for development
             single: {
-                singleRun: true,
+                singleRun: true
             }
         },
 
@@ -191,7 +191,7 @@ module.exports = function(grunt) {
         // configure grunt-concat for JavaScript file combining
         concat: {
             options: {
-                separator: ';\n',
+                separator: ';\n'
             },
             lib: {
                 nonull: true,
@@ -241,7 +241,7 @@ module.exports = function(grunt) {
                 src: [clientIncludeOrder.poSourceFiles],
                 dest: clientIncludeOrder.poJsonDest
             }
-        },
+        }
 
     });
 

--- a/client/client-files-config.js
+++ b/client/client-files-config.js
@@ -68,7 +68,7 @@ module.exports = {
         'client/js/models/*.js': ['coverage'],
         'client/js/collections/*.js': ['coverage'],
         'client/js/views/*.js': ['coverage'],
-        'goldstone/**/static/client-dev/**/*.js': ['coverage'],
+        'goldstone/**/static/client-dev/**/*.js': ['coverage']
     },
     coverageReportOutput: 'test/results/coverage',
 
@@ -88,7 +88,7 @@ module.exports = {
     complianceConcatWildcards: [
         'goldstone/compliance/static/client-dev/head/*.js',
         'goldstone/compliance/static/client-dev/middle/*.js',
-        'goldstone/compliance/static/client-dev/tail/*.js',
+        'goldstone/compliance/static/client-dev/tail/*.js'
     ],
     complianceConcatBundle: 'goldstone/compliance/static/client-js/compliance.js',
     complianceCopyFolder: 'goldstone/compliance/static/',

--- a/client/js/collections/apiHistogramCollection.js
+++ b/client/js/collections/apiHistogramCollection.js
@@ -63,7 +63,7 @@ var ApiHistogramCollection = GoldstoneBaseCollection.extend({
         var self = this;
 
         // initialize container for formatted results
-        finalResult = [];
+        var finalResult = [];
 
         // for each array index in the 'data' key
         _.each(data.aggregations.per_interval.buckets, function(item) {

--- a/client/js/collections/eventsHistogramCollection.js
+++ b/client/js/collections/eventsHistogramCollection.js
@@ -63,7 +63,7 @@ var EventsHistogramCollection = GoldstoneBaseCollection.extend({
         var self = this;
 
         // initialize container for formatted results
-        finalResult = [];
+        var finalResult = [];
 
         // for each array index in the 'data' key
         _.each(data.aggregations.per_interval.buckets, function(item) {

--- a/client/js/collections/logBrowserCollection.js
+++ b/client/js/collections/logBrowserCollection.js
@@ -41,6 +41,8 @@ instantiated in logSearchPageView.js as:
 
 var LogBrowserCollection = GoldstoneBaseCollection.extend({
 
+    // this.filter is set via logBrowserViz upon instantiation.
+
     isZoomed: false,
     zoomedStart: null,
     zoomedEnd: null,
@@ -85,10 +87,27 @@ var LogBrowserCollection = GoldstoneBaseCollection.extend({
     },
 
     addCustom: function(custom) {
-        
+
+        var result = '&syslog_severity__terms=[';
+
+        var levels = this.filter || {};
+        for (var k in levels) {
+            if (levels[k]) {
+                result = result.concat('"', k.toLowerCase(), '",');
+            }
+        }
+        result += "]";
+
+        result = result.slice(0, result.indexOf(',]'));
+        result += "]";
+
         // specificHost applies to this chart when instantiated
         // on a node report page to scope it to that node
-        return this.specificHost ? '&host=' + this.specificHost : '';
+        if (this.specificHost) {
+            result += '&host=' + this.specificHost;
+        }
+
+        return result;
     },
 
     triggerDataTableFetch: function() {

--- a/client/js/collections/logBrowserCollection.js
+++ b/client/js/collections/logBrowserCollection.js
@@ -91,4 +91,9 @@ var LogBrowserCollection = GoldstoneBaseCollection.extend({
         return this.specificHost ? '&host=' + this.specificHost : '';
     },
 
+    triggerDataTableFetch: function() {
+        // hook for logBrowserViz to initiate refresh and fetch
+        this.linkedDataTable.update();
+    }
+
 });

--- a/client/js/collections/logBrowserCollection.js
+++ b/client/js/collections/logBrowserCollection.js
@@ -19,31 +19,21 @@
 /*
 instantiated in logSearchPageView.js as:
 
-        this.logBrowserVizCollection = new LogBrowserCollection({
+        this.logSearchObserverCollection = new LogBrowserCollection({
             urlBase: '/core/logs/',
+            skipFetch: true,
 
             // specificHost applies to this chart when instantiated
             // on a node report page to scope it to that node
             specificHost: this.specificHost,
         });
-
-        this.logBrowserViz = new LogBrowserViz({
-            chartTitle: goldstone.contextTranslate('Logs vs Time', 'logbrowserpage'),
-            collection: this.logBrowserVizCollection,
-            el: '#log-viewer-visualization',
-            height: 300,
-            infoText: 'logBrowser',
-            marginLeft: 60,
-            width: $('#log-viewer-visualization').width(),
-            yAxisLabel: goldstone.contextTranslate('Log Events', 'logbrowserpage'),
-        });
 */
 
 var LogBrowserCollection = GoldstoneBaseCollection.extend({
 
-    // this.filter is set via logBrowserViz upon instantiation.
-    // predefinedUrlBase is set via predefinedSearchDropdown and set to
-    // null when clearning out saved searches
+    // "this.filter" is set via logBrowserViz upon instantiation.
+    // "this.modifyUrlBase" is used to modify the urlBase when a
+    // predefinedSearchDropdown search is triggered
 
     isZoomed: false,
     zoomedStart: null,
@@ -59,22 +49,25 @@ var LogBrowserCollection = GoldstoneBaseCollection.extend({
 
     },
 
-    // overwrite this, as the aggregation for this chart is idential on
-    // the additional pages. The additional pages are only relevant to the
-    // server-side paginated fetching for the log browser below the viz
     checkForAdditionalPages: function() {
+
+        // additional pages are not relevant, as only the
+        // results/aggregations will be used.
         return true;
     },
 
     modifyUrlBase: function(url) {
+
+        // allows predefinedSearchView to alter the urlBase and set it
+        // back to the original value by passing null.
+
         this.originalUrlBase = this.originalUrlBase || this.urlBase;
 
-        if(url === null) {
+        if (url === null) {
             this.urlBase = this.originalUrlBase;
         } else {
             this.urlBase = url;
         }
-
     },
 
     addInterval: function() {
@@ -101,6 +94,7 @@ var LogBrowserCollection = GoldstoneBaseCollection.extend({
 
     addCustom: function(custom) {
 
+        // adds parmaters that match the selected severity filters
         var result = '&syslog_severity__terms=[';
 
         var levels = this.filter || {};

--- a/client/js/collections/logBrowserCollection.js
+++ b/client/js/collections/logBrowserCollection.js
@@ -42,6 +42,8 @@ instantiated in logSearchPageView.js as:
 var LogBrowserCollection = GoldstoneBaseCollection.extend({
 
     // this.filter is set via logBrowserViz upon instantiation.
+    // predefinedUrlBase is set via predefinedSearchDropdown and set to
+    // null when clearning out saved searches
 
     isZoomed: false,
     zoomedStart: null,
@@ -62,6 +64,17 @@ var LogBrowserCollection = GoldstoneBaseCollection.extend({
     // server-side paginated fetching for the log browser below the viz
     checkForAdditionalPages: function() {
         return true;
+    },
+
+    modifyUrlBase: function(url) {
+        this.originalUrlBase = this.originalUrlBase || this.urlBase;
+
+        if(url === null) {
+            this.urlBase = this.originalUrlBase;
+        } else {
+            this.urlBase = url;
+        }
+
     },
 
     addInterval: function() {

--- a/client/js/collections/logBrowserTableCollection.js
+++ b/client/js/collections/logBrowserTableCollection.js
@@ -45,7 +45,7 @@ var LogBrowserTableCollection = GoldstoneBaseCollection.extend({
     addCustom: function() {
         var result = '&syslog_severity__terms=[';
 
-        levels = this.filter || {};
+        var levels = this.filter || {};
         for (var k in levels) {
             if (levels[k]) {
                 result = result.concat('"', k.toLowerCase(), '",');

--- a/client/js/collections/logBrowserTableCollection.js
+++ b/client/js/collections/logBrowserTableCollection.js
@@ -75,6 +75,6 @@ var LogBrowserTableCollection = GoldstoneBaseCollection.extend({
             this.epochNow = this.linkedCollection.epochNow;
         }
 
-    },
+    }
 
 });

--- a/client/js/collections/serviceStatusCollection.js
+++ b/client/js/collections/serviceStatusCollection.js
@@ -47,7 +47,7 @@ var ServiceStatusCollection = GoldstoneBaseCollection.extend({
     // Overwriting. Additinal pages not needed.
     checkForAdditionalPages: function(data) {
         return true;
-    },
+    }
 
 
 });

--- a/client/js/collections/spawnsCollection.js
+++ b/client/js/collections/spawnsCollection.js
@@ -57,7 +57,7 @@ var SpawnsCollection = GoldstoneBaseCollection.extend({
     addInterval: function() {
         n = Math.max(1, (this.globalLookback / 24));
         return '&interval=' + n + 'm';
-    },
+    }
 
     // creates a url similar to:
     // /nova/hypervisor/spawns/?@timestamp__range={"gte":1429027100000}&interval=1h

--- a/client/js/preload/base.js
+++ b/client/js/preload/base.js
@@ -133,34 +133,3 @@ goldstone.time.toPyTs = function(t) {
 window.onerror = function(message, fileURL, lineNumber) {
     console.log(message + ': ' + fileURL + ': ' + lineNumber);
 };
-
-// convenience for date manipulation
-Date.prototype.addSeconds = function(m) {
-    "use strict";
-    this.setTime(this.getTime() + (m * 1000));
-    return this;
-};
-
-Date.prototype.addMinutes = function(m) {
-    "use strict";
-    this.setTime(this.getTime() + (m * 60 * 1000));
-    return this;
-};
-
-Date.prototype.addHours = function(h) {
-    "use strict";
-    this.setTime(this.getTime() + (h * 60 * 60 * 1000));
-    return this;
-};
-
-Date.prototype.addDays = function(d) {
-    "use strict";
-    this.setTime(this.getTime() + (d * 24 * 60 * 60 * 1000));
-    return this;
-};
-
-Date.prototype.addWeeks = function(d) {
-    "use strict";
-    this.setTime(this.getTime() + (d * 7 * 24 * 60 * 60 * 1000));
-    return this;
-};

--- a/client/js/preload/goldstoneBaseView.js
+++ b/client/js/preload/goldstoneBaseView.js
@@ -302,11 +302,11 @@ var GoldstoneBaseView = Backbone.View.extend({
 
         var result = '<div class="btn-group" role="group">';
         _.each(routeArray, function(route) {
-            result += '<a href="' + route[0] + '"' + ' class="' + (route[2] === 'active' ? 'active ' : '') +
+            result += '<a href="' + route[0] + '" class="' + (route[2] === 'active' ? 'active ' : '') +
                 'btn btn-default">' + goldstone.translate(route[1]) + '</a>';
         });
         result += '</div><br><br>';
         return result;
-    },
+    }
 
 });

--- a/client/js/preload/utilizationCpuView.js
+++ b/client/js/preload/utilizationCpuView.js
@@ -263,7 +263,7 @@ var UtilizationCpuView = GoldstoneBaseView.extend({
         });
 
 
-        finalData = [];
+        var finalData = [];
 
         _.each(newData, function(item, i) {
 

--- a/client/js/views/apiBrowserDataTableView.js
+++ b/client/js/views/apiBrowserDataTableView.js
@@ -68,35 +68,35 @@ var ApiBrowserDataTableView = DataTableBaseView.extend({
                 }, {
                     "data": "_source.host",
                     "targets": 1,
-                    "sortable": false,
+                    "sortable": false
                 }, {
                     "data": "_source.client_ip",
                     "targets": 2,
-                    "sortable": false,
+                    "sortable": false
                 }, {
                     "data": "_source.uri",
                     "targets": 3,
-                    "sortable": false,
+                    "sortable": false
                 }, {
                     "data": "_source.response_status",
                     "targets": 4,
-                    "sortable": false,
+                    "sortable": false
                 }, {
                     "data": "_source.response_time",
                     "targets": 5,
-                    "sortable": false,
+                    "sortable": false
                 }, {
                     "data": "_source.response_length",
                     "targets": 6,
-                    "sortable": false,
+                    "sortable": false
                 }, {
                     "data": "_source.component",
                     "targets": 7,
-                    "sortable": false,
+                    "sortable": false
                 }, {
                     "data": "_source.type",
                     "targets": 8,
-                    "sortable": false,
+                    "sortable": false
                 }
 
             ],

--- a/client/js/views/apiBrowserPageView.js
+++ b/client/js/views/apiBrowserPageView.js
@@ -53,7 +53,7 @@ var ApiBrowserPageView = GoldstoneBasePageView.extend({
                 },
                 addInterval: function(interval) {
                     return '&interval=' + interval + 's';
-                },
+                }
             }),
             index_prefix: 'api_stats-*',
             settings_redirect: '/#reports/apibrowser/search'
@@ -77,7 +77,7 @@ var ApiBrowserPageView = GoldstoneBasePageView.extend({
     templateButtonSelectors: [
         ['/#reports/logbrowser', 'Log Viewer'],
         ['/#reports/eventbrowser', 'Event Viewer'],
-        ['/#reports/apibrowser', 'API Call Viewer', 'active'],
+        ['/#reports/apibrowser', 'API Call Viewer', 'active']
     ],
 
     template: _.template('' +

--- a/client/js/views/eventsBrowserDataTableView.js
+++ b/client/js/views/eventsBrowserDataTableView.js
@@ -321,7 +321,7 @@ var EventsBrowserDataTableView = DataTableBaseView.extend({
         'eventType': 1,
         'id': 2,
         'action': 3,
-        'outcome': 4,
+        'outcome': 4
     },
 
     // main template with placeholder for table

--- a/client/js/views/eventsBrowserPageView.js
+++ b/client/js/views/eventsBrowserPageView.js
@@ -79,7 +79,7 @@ var EventsBrowserPageView = GoldstoneBasePageView.extend({
     templateButtonSelectors: [
         ['/#reports/logbrowser', 'Log Viewer'],
         ['/#reports/eventbrowser', 'Event Viewer', 'active'],
-        ['/#reports/apibrowser', 'API Call Viewer'],
+        ['/#reports/apibrowser', 'API Call Viewer']
     ],
 
     template: _.template('' +

--- a/client/js/views/logBrowserDataTableView.js
+++ b/client/js/views/logBrowserDataTableView.js
@@ -72,7 +72,6 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
     // },
 
     update: function() {
-        console.log('in update');
         var oTable;
 
         if ($.fn.dataTable.isDataTable("#reports-result-table")) {

--- a/client/js/views/logBrowserDataTableView.js
+++ b/client/js/views/logBrowserDataTableView.js
@@ -37,7 +37,8 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
     },
 
     processListeners: function() {
-        return;
+        // overwriting to remove any chance of sensitivity to inherited
+        // listeners of lookback/refresh
     },
 
     processListenersForServerSide: function() {
@@ -46,46 +47,12 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
         // logBrowserViz view.
     },
 
-    // predefinedSearchUrl: null,
-
-    // predefinedSearch: function(uuid) {
-    //     var self = this;
-
-    //     // turn off refresh range as a signal to the user that refreshes
-    //     // will no longer be occuring without changing the lookback
-    //     // or refresh. setZoomed will block the action of the cached refresh
-    //     $('#global-refresh-range').val(-1);
-    //     this.trigger('setZoomed', true);
-
-    //     // the presence of a predefinedSearchUrl will take precidence
-    //     // when creating a fetch url in the ajax.beforeSend routine.
-    //     this.predefinedSearchUrl = uuid;
-    //     oTable = $("#reports-result-table").DataTable();
-    //     oTable.ajax.reload(function() {
-    //         setTimeout(function() {
-
-    //             // manually retrigger column auto adjust which was not firing
-    //             oTable.columns.adjust().draw();
-    //         }, 10);
-
-    //     });
-    // },
-
     update: function() {
         var oTable;
 
         if ($.fn.dataTable.isDataTable("#reports-result-table")) {
             oTable = $("#reports-result-table").DataTable();
-            oTable.ajax.reload(function() {
-                return true;
-                /*setTimeout(function() {
-
-                    // manually retrigger column auto adjust which was not firing
-                    // draw will kick off additional call to server fyi
-                    oTable.columns.adjust().draw();
-                }, 1000);*/
-
-            });
+            oTable.ajax.reload();
         }
     },
 

--- a/client/js/views/logBrowserDataTableView.js
+++ b/client/js/views/logBrowserDataTableView.js
@@ -36,6 +36,10 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
         this.drawSearchTableServerSide('#reports-result-table');
     },
 
+    processListeners: function() {
+        return;
+    },
+
     processListenersForServerSide: function() {
         // overwriting to remove sensitivity to global
         // refresh/lookback which is being listened to by the 
@@ -68,16 +72,19 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
     // },
 
     update: function() {
+        console.log('in update');
         var oTable;
 
         if ($.fn.dataTable.isDataTable("#reports-result-table")) {
             oTable = $("#reports-result-table").DataTable();
             oTable.ajax.reload(function() {
-                setTimeout(function() {
+                return true;
+                /*setTimeout(function() {
 
                     // manually retrigger column auto adjust which was not firing
+                    // draw will kick off additional call to server fyi
                     oTable.columns.adjust().draw();
-                }, 10);
+                }, 1000);*/
 
             });
         }

--- a/client/js/views/logBrowserDataTableView.js
+++ b/client/js/views/logBrowserDataTableView.js
@@ -37,41 +37,38 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
     },
 
     processListenersForServerSide: function() {
-        // overwriting so that dataTable only renders as a result of actions
-        // from viz above
+        // overwriting to remove sensitivity to global
+        // refresh/lookback which is being listened to by the 
+        // logBrowserViz view.
     },
 
-    predefinedSearchUrl: null,
+    // predefinedSearchUrl: null,
 
-    predefinedSearch: function(uuid) {
-        var self = this;
+    // predefinedSearch: function(uuid) {
+    //     var self = this;
 
-        // turn off refresh range as a signal to the user that refreshes
-        // will no longer be occuring without changing the lookback
-        // or refresh. setZoomed will block the action of the cached refresh
-        $('#global-refresh-range').val(-1);
-        this.trigger('setZoomed', true);
+    //     // turn off refresh range as a signal to the user that refreshes
+    //     // will no longer be occuring without changing the lookback
+    //     // or refresh. setZoomed will block the action of the cached refresh
+    //     $('#global-refresh-range').val(-1);
+    //     this.trigger('setZoomed', true);
 
-        // the presence of a predefinedSearchUrl will take precidence
-        // when creating a fetch url in the ajax.beforeSend routine.
-        this.predefinedSearchUrl = uuid;
-        oTable = $("#reports-result-table").DataTable();
-        oTable.ajax.reload(function() {
-            setTimeout(function() {
+    //     // the presence of a predefinedSearchUrl will take precidence
+    //     // when creating a fetch url in the ajax.beforeSend routine.
+    //     this.predefinedSearchUrl = uuid;
+    //     oTable = $("#reports-result-table").DataTable();
+    //     oTable.ajax.reload(function() {
+    //         setTimeout(function() {
 
-                // manually retrigger column auto adjust which was not firing
-                oTable.columns.adjust().draw();
-            }, 10);
+    //             // manually retrigger column auto adjust which was not firing
+    //             oTable.columns.adjust().draw();
+    //         }, 10);
 
-        });
-    },
+    //     });
+    // },
 
     update: function() {
         var oTable;
-
-        // clear out the saved search url so next time the viz is
-        // triggered it will not return the previously saved url
-        this.predefinedSearchUrl = null;
 
         if ($.fn.dataTable.isDataTable("#reports-result-table")) {
             oTable = $("#reports-result-table").DataTable();
@@ -145,9 +142,8 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
 
                     var urlOrderingDirection = decodeURIComponent(settings.url).match(/order\[0\]\[dir\]=(asc|desc)/gi);
 
-                    // if a predefined search url has been set
-                    // use that instead of the generated url
-                    settings.url = (self.predefinedSearchUrl ? self.predefinedSearchUrl + '?' : self.collectionMixin.url + '&') + "page_size=" + pageSize +
+
+                    settings.url = self.collectionMixin.url + '&page_size=' + pageSize +
                         "&page=" + computeStartPage;
 
                     // here begins the combiation of additional params
@@ -185,7 +181,7 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
 
                         // uncomment when ordering is in place.
                         // settings.url = settings.url + "&ordering=" +
-                            // ascDec + columnLabelHash[orderByColumn];
+                        // ascDec + columnLabelHash[orderByColumn];
                     }
 
                 },
@@ -199,6 +195,7 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
     },
 
     serverSideDataPrep: function(data) {
+        var self = this;
         data = JSON.parse(data);
 
         _.each(data.results, function(item) {
@@ -211,6 +208,12 @@ var LogBrowserDataTableView = DataTableBaseView.extend({
             item.log_message = item._source.log_message || '';
             item.host = item._source.host || '';
         });
+
+        // send data to collection to be rendered via logBrowserViz
+        // when the 'sync' event is triggered
+        self.collectionMixin.reset();
+        self.collectionMixin.add(data);
+        self.collectionMixin.trigger('sync');
 
         var result = {
             results: data.results,

--- a/client/js/views/logBrowserViz.js
+++ b/client/js/views/logBrowserViz.js
@@ -645,6 +645,6 @@ var LogBrowserViz = GoldstoneBaseView.extend({
         $(this.el).find('.special-icon-pre').append('<i class ="fa fa-lg fa-backward pull-right" style="margin: 0 5px 0 0"></i>');
         this.$el.append(this.filterModal());
         return this;
-    },
+    }
 
 });

--- a/client/js/views/logBrowserViz.js
+++ b/client/js/views/logBrowserViz.js
@@ -92,16 +92,16 @@ var LogBrowserViz = GoldstoneBaseView.extend({
     },
 
     // will prevent updating when zoom is active
-    isZoomed: false,
+    // isZoomed: false,
 
-    predefinedSearch: function(payload) {
-        this.collection.reset();
-        this.collection.add(payload);
-        this.update();
-    },
+    // predefinedSearch: function(payload) {
+    //     this.collection.reset();
+    //     this.collection.add(payload);
+    //     this.update();
+    // },
 
     setZoomed: function(bool) {
-        this.isZoomed = bool;
+        // this.isZoomed = bool;
         this.collection.isZoomed = bool;
     },
 
@@ -113,7 +113,7 @@ var LogBrowserViz = GoldstoneBaseView.extend({
     },
 
     constructUrl: function() {
-        this.collection.urlGenerator();
+        this.collection.triggerDataTableFetch();
     },
 
     processListeners: function() {
@@ -122,30 +122,29 @@ var LogBrowserViz = GoldstoneBaseView.extend({
         this.listenTo(this.collection, 'sync', function() {
             self.update();
         });
-
         this.listenTo(this.collection, 'error', this.dataErrorMessage);
 
         this.listenTo(this, 'lookbackSelectorChanged', function() {
             self.showSpinner();
             self.setZoomed(false);
             self.constructUrl();
-            this.trigger('chartUpdate');
+            // this.trigger('chartUpdate');
         });
 
         this.listenTo(this, 'refreshSelectorChanged', function() {
             self.showSpinner();
             self.setZoomed(false);
             self.constructUrl();
-            this.trigger('chartUpdate');
+            // this.trigger('chartUpdate');
         });
 
         this.listenTo(this, 'lookbackIntervalReached', function() {
-            if (self.isZoomed === true) {
-                return;
-            }
+            // if (self.isZoomed === true) {
+            //     return;
+            // }
             this.showSpinner();
             this.constructUrl();
-            this.trigger('chartUpdate');
+            // this.trigger('chartUpdate');
         });
 
     },
@@ -283,7 +282,7 @@ var LogBrowserViz = GoldstoneBaseView.extend({
         this.collection.zoomedEnd = Math.min(+new Date(), zoomedEnd);
 
         this.constructUrl();
-        this.trigger('chartUpdate');
+        // this.trigger('chartUpdate');
         return;
     },
 
@@ -599,7 +598,6 @@ var LogBrowserViz = GoldstoneBaseView.extend({
             .duration(500)
             .call(self.yAxis.scale(self.y));
 
-        // this.trigger('chartUpdate');
     },
 
     filterModal: _.template(

--- a/client/js/views/logBrowserViz.js
+++ b/client/js/views/logBrowserViz.js
@@ -301,7 +301,7 @@ var LogBrowserViz = GoldstoneBaseView.extend({
         var data = collectionDataPayload.aggregations.per_interval.buckets;
 
         // prepare empty array to return at end
-        finalData = [];
+        var finalData = [];
 
         // layers of nested _.each calls
         // the first one iterates through each object

--- a/client/js/views/logBrowserViz.js
+++ b/client/js/views/logBrowserViz.js
@@ -140,7 +140,7 @@ var LogBrowserViz = GoldstoneBaseView.extend({
             // since refresh was changed via val() without select()
             // background timer will keep running and lookback will
             // continue to be triggered, so ignore if zoomed
-            if(this.collection.isZoomed === true) {
+            if (this.collection.isZoomed === true) {
                 return;
             }
             this.showSpinner();
@@ -220,6 +220,8 @@ var LogBrowserViz = GoldstoneBaseView.extend({
 
     specialInit: function() {
         var self = this;
+
+        this.collection.filter = this.filter;
 
         // ZOOM IN
         this.$el.find('.fa-search-plus').on('click', function() {
@@ -574,7 +576,12 @@ var LogBrowserViz = GoldstoneBaseView.extend({
         $(this.el).find('#populateEventFilters :checkbox').on('click', function() {
             var checkboxId = this.id;
             self.filter[checkboxId] = !self.filter[checkboxId];
-            self.update();
+            self.collection.filter = self.filter;
+
+            // after changing filter, do not have d3 re-render,
+            // but have dataTable refetch ajax
+            // with filter params incluced
+            self.constructUrl();
         });
 
         this.redraw();

--- a/client/js/views/logBrowserViz.js
+++ b/client/js/views/logBrowserViz.js
@@ -128,23 +128,23 @@ var LogBrowserViz = GoldstoneBaseView.extend({
             self.showSpinner();
             self.setZoomed(false);
             self.constructUrl();
-            // this.trigger('chartUpdate');
         });
 
         this.listenTo(this, 'refreshSelectorChanged', function() {
             self.showSpinner();
             self.setZoomed(false);
             self.constructUrl();
-            // this.trigger('chartUpdate');
         });
 
         this.listenTo(this, 'lookbackIntervalReached', function() {
-            // if (self.isZoomed === true) {
-            //     return;
-            // }
+            // since refresh was changed via val() without select()
+            // background timer will keep running and lookback will
+            // continue to be triggered, so ignore if zoomed
+            if(this.collection.isZoomed === true) {
+                return;
+            }
             this.showSpinner();
             this.constructUrl();
-            // this.trigger('chartUpdate');
         });
 
     },
@@ -248,11 +248,6 @@ var LogBrowserViz = GoldstoneBaseView.extend({
         this.showSpinner();
         self.setZoomed(true);
 
-        var $gls = $('.global-refresh-selector select');
-        if ($gls.length) {
-            $('.global-refresh-selector select').val(-1);
-        }
-
         var zoomedStart;
         var zoomedEnd;
 
@@ -281,8 +276,17 @@ var LogBrowserViz = GoldstoneBaseView.extend({
         this.collection.zoomedStart = zoomedStart;
         this.collection.zoomedEnd = Math.min(+new Date(), zoomedEnd);
 
+
+        var $gls = $('.global-refresh-selector select');
+        if ($gls.length) {
+            // change() required to mimic user enacted change and 
+            // shut off pageView timer that triggers lookbackIntervalReached
+            if (parseInt($gls.val(), 10) > 0) {
+                $gls.val(-1);
+            }
+        }
+
         this.constructUrl();
-        // this.trigger('chartUpdate');
         return;
     },
 

--- a/client/js/views/logSearchPageView.js
+++ b/client/js/views/logSearchPageView.js
@@ -24,6 +24,7 @@ in the top also affect the table on the bottom via a 'trigger'.
 var LogSearchPageView = GoldstoneBasePageView.extend({
 
     triggerChange: function(change) {
+        console.log('LogSearchPageView trigger ', change);
         this.logBrowserViz.trigger(change);
         // this.logBrowserTable.trigger(change);
     },

--- a/client/js/views/logSearchPageView.js
+++ b/client/js/views/logSearchPageView.js
@@ -24,7 +24,6 @@ in the top also affect the table on the bottom via a 'trigger'.
 var LogSearchPageView = GoldstoneBasePageView.extend({
 
     triggerChange: function(change) {
-        console.log('LogSearchPageView trigger ', change);
         this.logBrowserViz.trigger(change);
         // this.logBrowserTable.trigger(change);
     },

--- a/client/js/views/logSearchPageView.js
+++ b/client/js/views/logSearchPageView.js
@@ -25,7 +25,6 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
 
     triggerChange: function(change) {
         this.logBrowserViz.trigger(change);
-        // this.logBrowserTable.trigger(change);
     },
 
     render: function() {
@@ -36,9 +35,13 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
     renderCharts: function() {
         var self = this;
 
+        // this is the single collection that holds state about
+        // zoom/filter/lookback/predefinedSearch/specificHost when
+        // url generation occurs in the dataTable
         this.logSearchObserverCollection = new LogBrowserCollection({
             urlBase: '/core/logs/',
             skipFetch: true,
+
             // specificHost applies to this chart when instantiated
             // on a node report page to scope it to that node
             specificHost: this.specificHost,
@@ -54,75 +57,31 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
             yAxisLabel: goldstone.contextTranslate('Log Events', 'logbrowserpage'),
         });
 
-        // this.logBrowserTableCollection = new LogBrowserTableCollection({
-        //     skipFetch: true,
-        //     specificHost: this.specificHost,
-        //     urlBase: '/core/logs/',
-        //     linkedCollection: this.logBrowserVizCollection
-        // });
-
         this.logBrowserTable = new LogBrowserDataTableView({
             chartTitle: goldstone.contextTranslate('Log Browser', 'logbrowserpage'),
             collectionMixin: this.logSearchObserverCollection,
             el: '#log-viewer-table',
-            infoIcon: 'fa-table',
             width: $('#log-viewer-table').width()
         });
-
-        // initial rendering of logBrowserTable:
-        // this.logBrowserTableCollection.filter = this.logBrowserViz.filter;
-        // this.logBrowserTable.update();
-
-        // set up listener between viz and table to setZoomed to 'true'
-        // when user triggers a saved search
-        // this.logBrowserViz.listenTo(this.logBrowserTable, 'setZoomed', function(trueFalse) {
-        //     this.setZoomed(trueFalse);
-        // });
 
         // render predefinedSearch Dropdown
         this.predefinedSearchDropdown = new PredefinedSearchView({
             collection: this.logSearchObserverCollection,
-            // collection: new GoldstoneBaseCollection({
-            //     skipFetch: true,
-            //     urlBase: '',
-            //     addRange: function() {
-            //         return '?@timestamp__range={"gte":' + this.gte + ',"lte":' + this.epochNow + '}';
-            //     },
-            //     addInterval: function(interval) {
-            //         return '&interval=' + interval + 's';
-            //     },
-            // }),
             index_prefix: 'logstash-*',
             settings_redirect: '/#reports/logbrowser/search'
         });
 
         this.logBrowserViz.$el.find('.panel-primary').prepend(this.predefinedSearchDropdown.el);
 
-
+        // create linkage from the master collection back to the viz'
         this.logSearchObserverCollection.linkedViz = this.logBrowserViz;
         this.logSearchObserverCollection.linkedDataTable = this.logBrowserTable;
         this.logSearchObserverCollection.linkedDropdown = this.predefinedSearchDropdown;
 
-        // subscribe logBrowserViz to click events on predefined
-        // search dropdown to fetch results.
-        // this.listenTo(this.predefinedSearchDropdown, 'clickedUuidViz', function(uuid) {
-            // self.logBrowserTable.predefinedSearch(uuid[1]);
-            // self.logBrowserViz.predefinedSearch(uuid[0]);
-        // });
-        // this.listenTo(this.predefinedSearchDropdown, 'clickedUuidTable', function(uuid) {
-            // self.logBrowserTable.predefinedSearch(uuid[1]);
-            // self.logBrowserViz.predefinedSearch(uuid[0]);
-        // });
-
-        // set up a chain of events between viz and table to uddate
-        // table when updating viz.
-        // this.listenTo(this.logBrowserViz, 'chartUpdate', function() {
-        //     self.logBrowserTableCollection.filter = self.logBrowserViz.filter;
-        //     self.logBrowserTable.update();
-        // });
-
+        // TODO: delete logBrowserTableCollection
+        
         // destroy listeners and views upon page close
-        this.viewsToStopListening = [this.logSearchObserverCollection, /*this.logBrowserVizCollection,*/ this.logBrowserViz, /*this.logBrowserTableCollection,*/ this.logBrowserTable, this.predefinedSearchDropdown];
+        this.viewsToStopListening = [this.logSearchObserverCollection, this.logBrowserViz, this.logBrowserTable, this.predefinedSearchDropdown];
 
     },
 

--- a/client/js/views/logSearchPageView.js
+++ b/client/js/views/logSearchPageView.js
@@ -25,7 +25,7 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
 
     triggerChange: function(change) {
         this.logBrowserViz.trigger(change);
-        this.logBrowserTable.trigger(change);
+        // this.logBrowserTable.trigger(change);
     },
 
     render: function() {
@@ -34,11 +34,11 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
     },
 
     renderCharts: function() {
-
         var self = this;
-        this.logBrowserVizCollection = new LogBrowserCollection({
-            urlBase: '/core/logs/',
 
+        this.logSearchObserverCollection = new LogBrowserCollection({
+            urlBase: '/core/logs/',
+            skipFetch: true,
             // specificHost applies to this chart when instantiated
             // on a node report page to scope it to that node
             specificHost: this.specificHost,
@@ -46,7 +46,7 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
 
         this.logBrowserViz = new LogBrowserViz({
             chartTitle: goldstone.contextTranslate('Log Search', 'logbrowserpage'),
-            collection: this.logBrowserVizCollection,
+            collection: this.logSearchObserverCollection,
             el: '#log-viewer-visualization',
             infoText: 'logBrowser',
             marginLeft: 70,
@@ -54,70 +54,75 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
             yAxisLabel: goldstone.contextTranslate('Log Events', 'logbrowserpage'),
         });
 
-        this.logBrowserTableCollection = new LogBrowserTableCollection({
-            skipFetch: true,
-            specificHost: this.specificHost,
-            urlBase: '/core/logs/',
-            linkedCollection: this.logBrowserVizCollection
-        });
+        // this.logBrowserTableCollection = new LogBrowserTableCollection({
+        //     skipFetch: true,
+        //     specificHost: this.specificHost,
+        //     urlBase: '/core/logs/',
+        //     linkedCollection: this.logBrowserVizCollection
+        // });
 
         this.logBrowserTable = new LogBrowserDataTableView({
             chartTitle: goldstone.contextTranslate('Log Browser', 'logbrowserpage'),
-            collectionMixin: this.logBrowserTableCollection,
+            collectionMixin: this.logSearchObserverCollection,
             el: '#log-viewer-table',
             infoIcon: 'fa-table',
             width: $('#log-viewer-table').width()
         });
 
         // initial rendering of logBrowserTable:
-        this.logBrowserTableCollection.filter = this.logBrowserViz.filter;
-        this.logBrowserTable.update();
+        // this.logBrowserTableCollection.filter = this.logBrowserViz.filter;
+        // this.logBrowserTable.update();
 
         // set up listener between viz and table to setZoomed to 'true'
         // when user triggers a saved search
-        this.logBrowserViz.listenTo(this.logBrowserTable, 'setZoomed', function(trueFalse) {
-            this.setZoomed(trueFalse);
-        });
+        // this.logBrowserViz.listenTo(this.logBrowserTable, 'setZoomed', function(trueFalse) {
+        //     this.setZoomed(trueFalse);
+        // });
 
         // render predefinedSearch Dropdown
         this.predefinedSearchDropdown = new PredefinedSearchView({
-            collection: new GoldstoneBaseCollection({
-                skipFetch: true,
-                urlBase: '',
-                addRange: function() {
-                    return '?@timestamp__range={"gte":' + this.gte + ',"lte":' + this.epochNow + '}';
-                },
-                addInterval: function(interval) {
-                    return '&interval=' + interval + 's';
-                },
-            }),
+            collection: this.logSearchObserverCollection,
+            // collection: new GoldstoneBaseCollection({
+            //     skipFetch: true,
+            //     urlBase: '',
+            //     addRange: function() {
+            //         return '?@timestamp__range={"gte":' + this.gte + ',"lte":' + this.epochNow + '}';
+            //     },
+            //     addInterval: function(interval) {
+            //         return '&interval=' + interval + 's';
+            //     },
+            // }),
             index_prefix: 'logstash-*',
             settings_redirect: '/#reports/logbrowser/search'
-
         });
 
         this.logBrowserViz.$el.find('.panel-primary').prepend(this.predefinedSearchDropdown.el);
 
+
+        this.logSearchObserverCollection.linkedViz = this.logBrowserViz;
+        this.logSearchObserverCollection.linkedDataTable = this.logBrowserTable;
+        this.logSearchObserverCollection.linkedDropdown = this.predefinedSearchDropdown;
+
         // subscribe logBrowserViz to click events on predefined
         // search dropdown to fetch results.
-        this.listenTo(this.predefinedSearchDropdown, 'clickedUuidViz', function(uuid) {
+        // this.listenTo(this.predefinedSearchDropdown, 'clickedUuidViz', function(uuid) {
             // self.logBrowserTable.predefinedSearch(uuid[1]);
-            self.logBrowserViz.predefinedSearch(uuid[0]);
-        });
-        this.listenTo(this.predefinedSearchDropdown, 'clickedUuidTable', function(uuid) {
-            self.logBrowserTable.predefinedSearch(uuid[1]);
             // self.logBrowserViz.predefinedSearch(uuid[0]);
-        });
+        // });
+        // this.listenTo(this.predefinedSearchDropdown, 'clickedUuidTable', function(uuid) {
+            // self.logBrowserTable.predefinedSearch(uuid[1]);
+            // self.logBrowserViz.predefinedSearch(uuid[0]);
+        // });
 
         // set up a chain of events between viz and table to uddate
         // table when updating viz.
-        this.listenTo(this.logBrowserViz, 'chartUpdate', function() {
-            self.logBrowserTableCollection.filter = self.logBrowserViz.filter;
-            self.logBrowserTable.update();
-        });
+        // this.listenTo(this.logBrowserViz, 'chartUpdate', function() {
+        //     self.logBrowserTableCollection.filter = self.logBrowserViz.filter;
+        //     self.logBrowserTable.update();
+        // });
 
         // destroy listeners and views upon page close
-        this.viewsToStopListening = [this.logBrowserVizCollection, this.logBrowserViz, this.logBrowserTableCollection, this.logBrowserTable, this.predefinedSearchDropdown];
+        this.viewsToStopListening = [this.logSearchObserverCollection, /*this.logBrowserVizCollection,*/ this.logBrowserViz, /*this.logBrowserTableCollection,*/ this.logBrowserTable, this.predefinedSearchDropdown];
 
     },
 

--- a/client/js/views/logSearchPageView.js
+++ b/client/js/views/logSearchPageView.js
@@ -54,7 +54,7 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
             infoText: 'logBrowser',
             marginLeft: 70,
             width: $('#log-viewer-visualization').width(),
-            yAxisLabel: goldstone.contextTranslate('Log Events', 'logbrowserpage'),
+            yAxisLabel: goldstone.contextTranslate('Log Events', 'logbrowserpage')
         });
 
         this.logBrowserTable = new LogBrowserDataTableView({
@@ -88,7 +88,7 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
     templateButtonSelectors: [
         ['/#reports/logbrowser', 'Log Viewer', 'active'],
         ['/#reports/eventbrowser', 'Event Viewer'],
-        ['/#reports/apibrowser', 'API Call Viewer'],
+        ['/#reports/apibrowser', 'API Call Viewer']
     ],
 
     template: _.template('' +

--- a/client/js/views/metricOverviewView.js
+++ b/client/js/views/metricOverviewView.js
@@ -517,7 +517,7 @@ var MetricOverviewView = ChartSet.extend({
         WARNING: false,
         NOTICE: false,
         INFO: false,
-        DEBUG: false,
+        DEBUG: false
     }
 
 });

--- a/client/js/views/nodeReportPageView.js
+++ b/client/js/views/nodeReportPageView.js
@@ -337,7 +337,7 @@ var NodeReportPageView = GoldstoneBasePageView.extend({
             marginLeft: 60,
             urlRoot: "/logging/summarize/?",
             width: $('#log-viewer-visualization').width(),
-            yAxisLabel: goldstone.contextTranslate('Log Events', 'logbrowserpage'),
+            yAxisLabel: goldstone.contextTranslate('Log Events', 'logbrowserpage')
         });
 
         this.logBrowserTableCollection = new LogBrowserTableCollection({

--- a/client/js/views/predefinedSearchView.js
+++ b/client/js/views/predefinedSearchView.js
@@ -128,40 +128,43 @@ PredefinedSearchView = GoldstoneBaseView.extend({
                 // calls function that will provide accurate translation
                 // if in a different language environment
                 $('#predefined-search-title').text(self.generateDropdownName());
+                self.collection.modifyUrlBase(null);
+                self.collection.triggerDataTableFetch();
             } else {
 
                 // append search name to predefined search dropdown title
                 $('#predefined-search-title').text($(this).text());
+
+                var constructedUrlForTable = '/core/saved_search/' + clickedUuid + '/results/';
+                self.collection.modifyUrlBase(constructedUrlForTable);
+                self.collection.triggerDataTableFetch();
             }
 
-            var constructedUrlForTable = '/core/saved_search/' + clickedUuid + '/results/';
 
-            self.collection.urlBase = '/core/saved_search/' + clickedUuid + '/results/';
-            self.collection.urlGenerator();
-            var constructedUrlforViz = self.collection.url;
-            self.fetchResults(constructedUrlforViz, constructedUrlForTable);
+            // var constructedUrlforViz = self.collection.url;
+            // self.fetchResults(constructedUrlforViz, constructedUrlForTable);
         });
 
     },
 
-    fetchResults: function(vizUrl, tableUrl) {
-        var self = this;
-        $.get(vizUrl)
-            .done(function(res) {
-                self.trigger('clickedUuidViz', [res, vizUrl]);
-            })
-            .fail(function(err) {
-                console.error(err);
-            });
+    // fetchResults: function(vizUrl, tableUrl) {
+    //     var self = this;
+    //     $.get(vizUrl)
+    //         .done(function(res) {
+    //             self.trigger('clickedUuidViz', [res, vizUrl]);
+    //         })
+    //         .fail(function(err) {
+    //             console.error(err);
+    //         });
 
-        $.get(tableUrl)
-            .done(function(res) {
-                self.trigger('clickedUuidTable', [res, tableUrl]);
-            })
-            .fail(function(err) {
-                console.error(err);
-            });
-    },
+    //     $.get(tableUrl)
+    //         .done(function(res) {
+    //             self.trigger('clickedUuidTable', [res, tableUrl]);
+    //         })
+    //         .fail(function(err) {
+    //             console.error(err);
+    //         });
+    // },
 
     generateDropdownName: function() {
 

--- a/client/js/views/predefinedSearchView.js
+++ b/client/js/views/predefinedSearchView.js
@@ -36,26 +36,16 @@ compliance/defined_search/ results structure:
 
 instantiated on logSearchPageView as:
 
+    // render predefinedSearch Dropdown
     this.predefinedSearchDropdown = new PredefinedSearchView({
-        collection: new GoldstoneBaseCollection({
-            skipFetch: true,
-            urlBase: '',
-            addRange: function() {
-                return '?@timestamp__range={"gte":' + this.gte + ',"lte":' + this.epochNow + '}';
-            },
-            addInterval: function(interval) {
-                return '&interval=' + interval + 's';
-            },
-        }),
+        collection: this.logSearchObserverCollection,
         index_prefix: 'logstash-*',
         settings_redirect: '/#reports/logbrowser/search'
-
     });
 
     this.logBrowserViz.$el.find('.panel-primary').prepend(this.predefinedSearchDropdown.el);
 
     also instantiated on eventsBrowserPageView and apiBrowserPageView
-
 */
 
 PredefinedSearchView = GoldstoneBaseView.extend({
@@ -140,31 +130,9 @@ PredefinedSearchView = GoldstoneBaseView.extend({
                 self.collection.triggerDataTableFetch();
             }
 
-
-            // var constructedUrlforViz = self.collection.url;
-            // self.fetchResults(constructedUrlforViz, constructedUrlForTable);
         });
 
     },
-
-    // fetchResults: function(vizUrl, tableUrl) {
-    //     var self = this;
-    //     $.get(vizUrl)
-    //         .done(function(res) {
-    //             self.trigger('clickedUuidViz', [res, vizUrl]);
-    //         })
-    //         .fail(function(err) {
-    //             console.error(err);
-    //         });
-
-    //     $.get(tableUrl)
-    //         .done(function(res) {
-    //             self.trigger('clickedUuidTable', [res, tableUrl]);
-    //         })
-    //         .fail(function(err) {
-    //             console.error(err);
-    //         });
-    // },
 
     generateDropdownName: function() {
 

--- a/client/js/views/savedSearchPageView.js
+++ b/client/js/views/savedSearchPageView.js
@@ -64,7 +64,7 @@ SavedSearchPageView = GoldstoneBasePageView.extend({
         $("select#global-refresh-range").hide();
 
         this.savedSearchLogCollection = new GoldstoneBaseCollection({
-            skipFetch: true,
+            skipFetch: true
         });
         this.savedSearchLogCollection.urlBase = urlBase;
         this.savedSearchLogView = new SavedSearchDataTableView({

--- a/client/js/views/utilizationMemView.js
+++ b/client/js/views/utilizationMemView.js
@@ -90,7 +90,7 @@ var UtilizationMemView = UtilizationCpuView.extend({
 
         });
 
-        finalData = [];
+        var finalData = [];
 
         // make sure to set ns.memTotal
         var key = _.keys(allthelogs[0].per_interval[1])[0];

--- a/client/js/views/utilizationNetView.js
+++ b/client/js/views/utilizationNetView.js
@@ -96,7 +96,7 @@ var UtilizationNetView = UtilizationCpuView.extend({
 
 
 
-        finalData = [];
+        var finalData = [];
 
         _.each(newData, function(item, i) {
 

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -133,37 +133,7 @@ goldstone.time.toPyTs = function(t) {
 window.onerror = function(message, fileURL, lineNumber) {
     console.log(message + ': ' + fileURL + ': ' + lineNumber);
 };
-
-// convenience for date manipulation
-Date.prototype.addSeconds = function(m) {
-    "use strict";
-    this.setTime(this.getTime() + (m * 1000));
-    return this;
-};
-
-Date.prototype.addMinutes = function(m) {
-    "use strict";
-    this.setTime(this.getTime() + (m * 60 * 1000));
-    return this;
-};
-
-Date.prototype.addHours = function(h) {
-    "use strict";
-    this.setTime(this.getTime() + (h * 60 * 60 * 1000));
-    return this;
-};
-
-Date.prototype.addDays = function(d) {
-    "use strict";
-    this.setTime(this.getTime() + (d * 24 * 60 * 60 * 1000));
-    return this;
-};
-
-Date.prototype.addWeeks = function(d) {
-    "use strict";
-    this.setTime(this.getTime() + (d * 7 * 24 * 60 * 60 * 1000));
-    return this;
-};;
+;
 /**
  * Copyright 2015 Solinea, Inc.
  *
@@ -496,12 +466,12 @@ var GoldstoneBaseView = Backbone.View.extend({
 
         var result = '<div class="btn-group" role="group">';
         _.each(routeArray, function(route) {
-            result += '<a href="' + route[0] + '"' + ' class="' + (route[2] === 'active' ? 'active ' : '') +
+            result += '<a href="' + route[0] + '" class="' + (route[2] === 'active' ? 'active ' : '') +
                 'btn btn-default">' + goldstone.translate(route[1]) + '</a>';
         });
         result += '</div><br><br>';
         return result;
-    },
+    }
 
 });
 ;
@@ -3423,7 +3393,7 @@ var LogBrowserTableCollection = GoldstoneBaseCollection.extend({
             this.epochNow = this.linkedCollection.epochNow;
         }
 
-    },
+    }
 
 });
 ;
@@ -3774,7 +3744,7 @@ var ServiceStatusCollection = GoldstoneBaseCollection.extend({
     // Overwriting. Additinal pages not needed.
     checkForAdditionalPages: function(data) {
         return true;
-    },
+    }
 
 
 });
@@ -3838,7 +3808,7 @@ var SpawnsCollection = GoldstoneBaseCollection.extend({
     addInterval: function() {
         n = Math.max(1, (this.globalLookback / 24));
         return '&interval=' + n + 'm';
-    },
+    }
 
     // creates a url similar to:
     // /nova/hypervisor/spawns/?@timestamp__range={"gte":1429027100000}&interval=1h
@@ -4042,35 +4012,35 @@ var ApiBrowserDataTableView = DataTableBaseView.extend({
                 }, {
                     "data": "_source.host",
                     "targets": 1,
-                    "sortable": false,
+                    "sortable": false
                 }, {
                     "data": "_source.client_ip",
                     "targets": 2,
-                    "sortable": false,
+                    "sortable": false
                 }, {
                     "data": "_source.uri",
                     "targets": 3,
-                    "sortable": false,
+                    "sortable": false
                 }, {
                     "data": "_source.response_status",
                     "targets": 4,
-                    "sortable": false,
+                    "sortable": false
                 }, {
                     "data": "_source.response_time",
                     "targets": 5,
-                    "sortable": false,
+                    "sortable": false
                 }, {
                     "data": "_source.response_length",
                     "targets": 6,
-                    "sortable": false,
+                    "sortable": false
                 }, {
                     "data": "_source.component",
                     "targets": 7,
-                    "sortable": false,
+                    "sortable": false
                 }, {
                     "data": "_source.type",
                     "targets": 8,
-                    "sortable": false,
+                    "sortable": false
                 }
 
             ],
@@ -4233,7 +4203,7 @@ var ApiBrowserPageView = GoldstoneBasePageView.extend({
                 },
                 addInterval: function(interval) {
                     return '&interval=' + interval + 's';
-                },
+                }
             }),
             index_prefix: 'api_stats-*',
             settings_redirect: '/#reports/apibrowser/search'
@@ -4257,7 +4227,7 @@ var ApiBrowserPageView = GoldstoneBasePageView.extend({
     templateButtonSelectors: [
         ['/#reports/logbrowser', 'Log Viewer'],
         ['/#reports/eventbrowser', 'Event Viewer'],
-        ['/#reports/apibrowser', 'API Call Viewer', 'active'],
+        ['/#reports/apibrowser', 'API Call Viewer', 'active']
     ],
 
     template: _.template('' +
@@ -5563,7 +5533,7 @@ var EventsBrowserDataTableView = DataTableBaseView.extend({
         'eventType': 1,
         'id': 2,
         'action': 3,
-        'outcome': 4,
+        'outcome': 4
     },
 
     // main template with placeholder for table
@@ -5721,7 +5691,7 @@ var EventsBrowserPageView = GoldstoneBasePageView.extend({
     templateButtonSelectors: [
         ['/#reports/logbrowser', 'Log Viewer'],
         ['/#reports/eventbrowser', 'Event Viewer', 'active'],
-        ['/#reports/apibrowser', 'API Call Viewer'],
+        ['/#reports/apibrowser', 'API Call Viewer']
     ],
 
     template: _.template('' +
@@ -7601,7 +7571,7 @@ var LogBrowserViz = GoldstoneBaseView.extend({
         $(this.el).find('.special-icon-pre').append('<i class ="fa fa-lg fa-backward pull-right" style="margin: 0 5px 0 0"></i>');
         this.$el.append(this.filterModal());
         return this;
-    },
+    }
 
 });
 ;
@@ -7661,7 +7631,7 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
             infoText: 'logBrowser',
             marginLeft: 70,
             width: $('#log-viewer-visualization').width(),
-            yAxisLabel: goldstone.contextTranslate('Log Events', 'logbrowserpage'),
+            yAxisLabel: goldstone.contextTranslate('Log Events', 'logbrowserpage')
         });
 
         this.logBrowserTable = new LogBrowserDataTableView({
@@ -7695,7 +7665,7 @@ var LogSearchPageView = GoldstoneBasePageView.extend({
     templateButtonSelectors: [
         ['/#reports/logbrowser', 'Log Viewer', 'active'],
         ['/#reports/eventbrowser', 'Event Viewer'],
-        ['/#reports/apibrowser', 'API Call Viewer'],
+        ['/#reports/apibrowser', 'API Call Viewer']
     ],
 
     template: _.template('' +
@@ -8378,7 +8348,7 @@ var MetricOverviewView = ChartSet.extend({
         WARNING: false,
         NOTICE: false,
         INFO: false,
-        DEBUG: false,
+        DEBUG: false
     }
 
 });
@@ -9605,7 +9575,7 @@ var NodeReportPageView = GoldstoneBasePageView.extend({
             marginLeft: 60,
             urlRoot: "/logging/summarize/?",
             width: $('#log-viewer-visualization').width(),
-            yAxisLabel: goldstone.contextTranslate('Log Events', 'logbrowserpage'),
+            yAxisLabel: goldstone.contextTranslate('Log Events', 'logbrowserpage')
         });
 
         this.logBrowserTableCollection = new LogBrowserTableCollection({
@@ -11181,7 +11151,7 @@ SavedSearchPageView = GoldstoneBasePageView.extend({
         $("select#global-refresh-range").hide();
 
         this.savedSearchLogCollection = new GoldstoneBaseCollection({
-            skipFetch: true,
+            skipFetch: true
         });
         this.savedSearchLogCollection.urlBase = urlBase;
         this.savedSearchLogView = new SavedSearchDataTableView({

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -1953,7 +1953,7 @@ var UtilizationCpuView = GoldstoneBaseView.extend({
         });
 
 
-        finalData = [];
+        var finalData = [];
 
         _.each(newData, function(item, i) {
 
@@ -2780,7 +2780,7 @@ var ApiHistogramCollection = GoldstoneBaseCollection.extend({
         var self = this;
 
         // initialize container for formatted results
-        finalResult = [];
+        var finalResult = [];
 
         // for each array index in the 'data' key
         _.each(data.aggregations.per_interval.buckets, function(item) {
@@ -2957,7 +2957,7 @@ var EventsHistogramCollection = GoldstoneBaseCollection.extend({
         var self = this;
 
         // initialize container for formatted results
-        finalResult = [];
+        var finalResult = [];
 
         // for each array index in the 'data' key
         _.each(data.aggregations.per_interval.buckets, function(item) {
@@ -3362,7 +3362,7 @@ var LogBrowserTableCollection = GoldstoneBaseCollection.extend({
     addCustom: function() {
         var result = '&syslog_severity__terms=[';
 
-        levels = this.filter || {};
+        var levels = this.filter || {};
         for (var k in levels) {
             if (levels[k]) {
                 result = result.concat('"', k.toLowerCase(), '",');
@@ -7250,7 +7250,7 @@ var LogBrowserViz = GoldstoneBaseView.extend({
         var data = collectionDataPayload.aggregations.per_interval.buckets;
 
         // prepare empty array to return at end
-        finalData = [];
+        var finalData = [];
 
         // layers of nested _.each calls
         // the first one iterates through each object
@@ -13462,7 +13462,7 @@ var UtilizationMemView = UtilizationCpuView.extend({
 
         });
 
-        finalData = [];
+        var finalData = [];
 
         // make sure to set ns.memTotal
         var key = _.keys(allthelogs[0].per_interval[1])[0];
@@ -13588,7 +13588,7 @@ var UtilizationNetView = UtilizationCpuView.extend({
 
 
 
-        finalData = [];
+        var finalData = [];
 
         _.each(newData, function(item, i) {
 

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -3264,6 +3264,8 @@ instantiated in logSearchPageView.js as:
 var LogBrowserCollection = GoldstoneBaseCollection.extend({
 
     // this.filter is set via logBrowserViz upon instantiation.
+    // predefinedUrlBase is set via predefinedSearchDropdown and set to
+    // null when clearning out saved searches
 
     isZoomed: false,
     zoomedStart: null,
@@ -3284,6 +3286,17 @@ var LogBrowserCollection = GoldstoneBaseCollection.extend({
     // server-side paginated fetching for the log browser below the viz
     checkForAdditionalPages: function() {
         return true;
+    },
+
+    modifyUrlBase: function(url) {
+        this.originalUrlBase = this.originalUrlBase || this.urlBase;
+
+        if(url === null) {
+            this.urlBase = this.originalUrlBase;
+        } else {
+            this.urlBase = url;
+        }
+
     },
 
     addInterval: function() {
@@ -10172,40 +10185,43 @@ PredefinedSearchView = GoldstoneBaseView.extend({
                 // calls function that will provide accurate translation
                 // if in a different language environment
                 $('#predefined-search-title').text(self.generateDropdownName());
+                self.collection.modifyUrlBase(null);
+                self.collection.triggerDataTableFetch();
             } else {
 
                 // append search name to predefined search dropdown title
                 $('#predefined-search-title').text($(this).text());
+
+                var constructedUrlForTable = '/core/saved_search/' + clickedUuid + '/results/';
+                self.collection.modifyUrlBase(constructedUrlForTable);
+                self.collection.triggerDataTableFetch();
             }
 
-            var constructedUrlForTable = '/core/saved_search/' + clickedUuid + '/results/';
 
-            self.collection.urlBase = '/core/saved_search/' + clickedUuid + '/results/';
-            self.collection.urlGenerator();
-            var constructedUrlforViz = self.collection.url;
-            self.fetchResults(constructedUrlforViz, constructedUrlForTable);
+            // var constructedUrlforViz = self.collection.url;
+            // self.fetchResults(constructedUrlforViz, constructedUrlForTable);
         });
 
     },
 
-    fetchResults: function(vizUrl, tableUrl) {
-        var self = this;
-        $.get(vizUrl)
-            .done(function(res) {
-                self.trigger('clickedUuidViz', [res, vizUrl]);
-            })
-            .fail(function(err) {
-                console.error(err);
-            });
+    // fetchResults: function(vizUrl, tableUrl) {
+    //     var self = this;
+    //     $.get(vizUrl)
+    //         .done(function(res) {
+    //             self.trigger('clickedUuidViz', [res, vizUrl]);
+    //         })
+    //         .fail(function(err) {
+    //             console.error(err);
+    //         });
 
-        $.get(tableUrl)
-            .done(function(res) {
-                self.trigger('clickedUuidTable', [res, tableUrl]);
-            })
-            .fail(function(err) {
-                console.error(err);
-            });
-    },
+    //     $.get(tableUrl)
+    //         .done(function(res) {
+    //             self.trigger('clickedUuidTable', [res, tableUrl]);
+    //         })
+    //         .fail(function(err) {
+    //             console.error(err);
+    //         });
+    // },
 
     generateDropdownName: function() {
 

--- a/test/integration/logAnalysis_integrationTests.js
+++ b/test/integration/logAnalysis_integrationTests.js
@@ -42,7 +42,8 @@ describe('logAnalysis.js spec', function() {
 
 
         this.testCollection = new LogBrowserCollection({
-            urlBase: '/core/logs/'
+            urlBase: '/core/logs/',
+            skipFetch: true
         });
 
         blueSpinnerGif = "../../../goldstone/static/images/ajax-loader-solinea-blue.gif";
@@ -51,12 +52,20 @@ describe('logAnalysis.js spec', function() {
             chartTitle: goldstone.contextTranslate('Logs vs Time', 'logbrowserpage'),
             collection: this.testCollection,
             el: '#log-viewer-visualization',
-            height: 300,
             infoText: 'logBrowser',
-            marginLeft: 60,
+            marginLeft: 70,
             width: $('#log-viewer-visualization').width(),
             yAxisLabel: goldstone.contextTranslate('Log Events', 'logbrowserpage')
         });
+
+        this.testDataTableView = new LogBrowserDataTableView({
+            chartTitle: goldstone.contextTranslate('Log Browser', 'logbrowserpage'),
+            collectionMixin: this.testCollection,
+            el: '#log-viewer-table',
+            width: $('#log-viewer-table').width()
+        });
+
+        this.testCollection.linkedDataTable = this.testDataTableView;
 
         this.testCollection.reset();
         this.testCollection.add({
@@ -306,7 +315,7 @@ describe('logAnalysis.js spec', function() {
             expect(this.testCollection.url).to.include('&interval=');
             expect(this.constructUrl_spy.callCount).to.equal(2);
             // should not construct url
-            this.testView.isZoomed = true;
+            this.testView.collection.isZoomed = true;
             this.testView.trigger('lookbackIntervalReached');
             expect(this.constructUrl_spy.callCount).to.equal(2);
             this.constructUrl_spy.restore();

--- a/test/integration/predefinedSearchView_integrationTests.js
+++ b/test/integration/predefinedSearchView_integrationTests.js
@@ -45,22 +45,28 @@ describe('predefinedSearchView.js', function() {
 
         blueSpinnerGif = "goldstone/static/images/ajax-loader-solinea-blue.gif";
 
+        this.testCollection = new LogBrowserCollection({
+            urlBase: '/blah/de/blah/',
+            skipFetch: true
+        });
+
         this.testView = new PredefinedSearchView({
             className: 'compliance-predefined-search nav nav-pills',
             tagName: 'ul',
-            collection: new GoldstoneBaseCollection({
-                skipFetch: true,
-                urlBase: '',
-                addRange: function() {
-                    return '?@timestamp__range={"gte":' + this.gte + ',"lte":' + this.epochNow + '}';
-                },
-                addInterval: function(interval) {
-                    return '&interval=' + interval + 's';
-                },
-            })
+            collection: this.testCollection
         });
 
         $('.predefined-search-container').append(this.testView.el);
+
+        this.testDataTable = new LogBrowserDataTableView({
+            chartTitle: goldstone.contextTranslate('Log Browser', 'logbrowserpage'),
+            collectionMixin: this.testCollection,
+            el: '#log-viewer-table',
+            width: $('#log-viewer-table').width()
+        });
+
+        this.testCollection.linkedDataTable = this.testDataTable;
+
 
     });
     afterEach(function() {
@@ -104,7 +110,7 @@ describe('predefinedSearchView.js', function() {
                 name: 'test'
             }];
             this.testView.predefinedSearches = testArr;
-            this.testView.renderUpdatedResultList();   
+            this.testView.renderUpdatedResultList();
             expect($('.predefined-search-container').text()).to.match(/Predefined Searches/);
             $('[data-uuid="1234"]').click();
 

--- a/test/unit/unitTests.js
+++ b/test/unit/unitTests.js
@@ -64,23 +64,6 @@ describe('Testing the base.js file', function() {
                 expect(goldstone.time).to.have.property('toPyTs');
             });
         });
-        describe('the utility functions', function() {
-            it('date.prototype.functions', function() {
-                var a = new Date(10000000);
-                expect(a).to.be.a('date');
-                var b = +new Date(a.addSeconds(1));
-                expect(b).to.equal(10001000);
-                b = +new Date(a.addMinutes(1));
-                expect(b).to.equal(10061000);
-                b = +new Date(a.addHours(1));
-                expect(b).to.equal(13661000);
-                b = +new Date(a.addDays(1));
-                expect(b).to.equal(100061000);
-                b = +new Date(a.addWeeks(1));
-                expect(b).to.equal(704861000);
-            });
-        });
-
         describe('The time namespace', function() {
             it('should return dates with the correct formatting and order of magnitude', function() {
                 var time1 = goldstone.time.fromPyTs(42);
@@ -99,85 +82,6 @@ describe('Testing the base.js file', function() {
                 var timeTest3 = goldstone.time.toPyTs(time3);
                 expect(timeTest3).to.equal('1412376992');
             });
-        });
-    });
-
-    describe('Testing date functions', function() {
-        it('should properly compute date additions/subtractions', function() {
-            var d = new Date();
-            var dPlus = new Date(d.getTime());
-            dPlus.addSeconds(1);
-            expect(dPlus.getTime()).to.equal(d.getTime() + 1000);
-
-            d = new Date();
-            var dMinus = new Date(d.getTime());
-            dMinus.addSeconds(-1);
-            expect(dMinus.getTime()).to.equal(d.getTime() - 1000);
-
-            d = new Date();
-            dMinus = new Date(d.getTime());
-            dMinus.addSeconds(0);
-            expect(dMinus.getTime()).to.equal(d.getTime());
-
-            d = new Date();
-            dPlus = new Date(d.getTime());
-            dPlus.addMinutes(1);
-            expect(dPlus.getTime()).to.equal(d.getTime() + (60 * 1000));
-
-            d = new Date();
-            dPlus = new Date(d.getTime());
-            dPlus.addMinutes(-1);
-            expect(dPlus.getTime()).to.equal(d.getTime() - (60 * 1000));
-
-            d = new Date();
-            dPlus = new Date(d.getTime());
-            dPlus.addMinutes(0);
-            expect(dPlus.getTime()).to.equal(d.getTime());
-
-            d = new Date();
-            dPlus = new Date(d.getTime());
-            dPlus.addHours(1);
-            expect(dPlus.getTime()).to.equal(d.getTime() + (60 * 60 * 1000));
-
-            d = new Date();
-            dPlus = new Date(d.getTime());
-            dPlus.addHours(-1);
-            expect(dPlus.getTime()).to.equal(d.getTime() - (60 * 60 * 1000));
-
-            d = new Date();
-            dPlus = new Date(d.getTime());
-            dPlus.addHours(0);
-            expect(dPlus.getTime()).to.equal(d.getTime());
-
-            d = new Date();
-            dPlus = new Date(d.getTime());
-            dPlus.addDays(1);
-            expect(dPlus.getTime()).to.equal(d.getTime() + (24 * 60 * 60 * 1000));
-
-            d = new Date();
-            dPlus = new Date(d.getTime());
-            dPlus.addDays(-1);
-            expect(dPlus.getTime()).to.equal(d.getTime() - (24 * 60 * 60 * 1000));
-
-            d = new Date();
-            dPlus = new Date(d.getTime());
-            dPlus.addDays(0);
-            expect(dPlus.getTime()).to.equal(d.getTime());
-
-            d = new Date();
-            dPlus = new Date(d.getTime());
-            dPlus.addWeeks(1);
-            expect(dPlus.getTime()).to.equal(d.getTime() + (7 * 24 * 60 * 60 * 1000));
-
-            d = new Date();
-            dPlus = new Date(d.getTime());
-            dPlus.addWeeks(-1);
-            expect(dPlus.getTime()).to.equal(d.getTime() - (7 * 24 * 60 * 60 * 1000));
-
-            d = new Date();
-            dPlus = new Date(d.getTime());
-            dPlus.addWeeks(0);
-            expect(dPlus.getTime()).to.equal(d.getTime());
         });
     });
 });


### PR DESCRIPTION
Chart now 'does the right thing'.

to test, play around with the normal functionality + saved searches at:
http://localhost:8000/#reports/logbrowser

![image](https://cloud.githubusercontent.com/assets/5633015/12910227/87f19686-cebd-11e5-8431-ab5df8aa9ba7.png)

Also updates testing, and fixes a random assortment of complaints that were generated by CodeCoverage.

closes #211  