### PR TITLE
Resolves where the help and issues links go for both versions of goldstone server.

### DIFF
--- a/goldstone/templates/base.html
+++ b/goldstone/templates/base.html
@@ -66,17 +66,17 @@ limitations under the License.
                                 <i class="icon setting-icon">&nbsp;</i>
                                 <span class="i18n" data-i18n="Settings">Settings</span>
                             </a>
-                            <a href="https://solinea.freshdesk.com/support/tickets/new/" class="help">
+                            <a href="https://solinea.freshdesk.com/support/home" class="help">
                                 <i class="icon help-icon">&nbsp;</i>
-                                <span class="i18n" data-i18n="Help">Help</span>
+                                <span class="i18n" data-i18n="Support">Support</span>
                             </a>
                             <a href="https://groups.google.com/forum/#!forum/goldstone-users" class="google-group">
                                 <i class="icon google-group-icon">&nbsp;</i>
                                 <span class="i18n" data-i18n="Google Groups">Google Groups</span>
                             </a>
-                            <a href="https://github.com/Solinea/goldstone-server/issues" class="github">
+                            <a href="https://github.com/Solinea/goldstone-server" class="github">
                                 <i class="icon github-icon">&nbsp;</i>
-                                <span class="i18n" data-i18n="Github">Github Issues</span>
+                                <span class="i18n" data-i18n="Github Repo">Github Repo</span>
                             </a>
                             <a href="#" class="logout-btn shadow-block"><span class="i18n" data-i18n="Logout">
                                 Logout</span>


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/5633015/13406996/2d0702be-dedb-11e5-8808-6a4173853e6d.png)

"Support":
https://solinea.freshdesk.com/support/home

"Github":
https://github.com/Solinea/goldstone-server



closes #180 