### PR TITLE
Points to proprietary license when on compliance pages. Adds 'target' attributes.

### DIFF
--- a/client/js/preload/setBaseTemplateListeners.js
+++ b/client/js/preload/setBaseTemplateListeners.js
@@ -103,10 +103,22 @@ goldstone.setBaseTemplateListeners = function() {
         compliance: '.compliance-tab'
     };
 
+    var updateLicenseLink = function(name) {
+
+        // if navigating to compliance, update license
+        // link to proprietary software link
+        if (name === 'compliance') {
+            $('.dynamic-license').attr("href", "http://solinea.com/wp-content/uploads/2016/03/Solinea-Goldstone-Software-License-v1.0.pdf");
+        } else {
+            $('.dynamic-license').attr("href", "https://www.apache.org/licenses/LICENSE-2.0");
+        }
+    };
+
     // backbone router emits 'route' event on route change
     // and first argument is route name. Match to hash
     // to highlight the appropriate side menu nav icon
     goldstone.gsRouter.on('route', function(name) {
         addMenuIconHighlighting(routeNameToIconClassHash[name]);
+        updateLicenseLink(name);
     });
 };

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -218,11 +218,23 @@ goldstone.setBaseTemplateListeners = function() {
         compliance: '.compliance-tab'
     };
 
+    var updateLicenseLink = function(name) {
+
+        // if navigating to compliance, update license
+        // link to proprietary software link
+        if (name === 'compliance') {
+            $('.dynamic-license').attr("href", "http://solinea.com/wp-content/uploads/2016/03/Solinea-Goldstone-Software-License-v1.0.pdf");
+        } else {
+            $('.dynamic-license').attr("href", "https://www.apache.org/licenses/LICENSE-2.0");
+        }
+    };
+
     // backbone router emits 'route' event on route change
     // and first argument is route name. Match to hash
     // to highlight the appropriate side menu nav icon
     goldstone.gsRouter.on('route', function(name) {
         addMenuIconHighlighting(routeNameToIconClassHash[name]);
+        updateLicenseLink(name);
     });
 };
 ;

--- a/goldstone/templates/base.html
+++ b/goldstone/templates/base.html
@@ -192,10 +192,12 @@ limitations under the License.
                         : 1.0.0-SNAPSHOT
                         </span>
 
-                        <span class="copyright"><strong><span class="i18n" data-i18n="Copyright">Copyright</span> 2014-2016</strong> <a href="http://www.solinea.com/">Solinea, Inc.</a></span>
+                        <span class="copyright"><strong><span class="i18n" data-i18n="Copyright">Copyright</span> 2014-2016</strong> <a target="solinea_info" href="http://www.solinea.com/">Solinea, Inc.</a></span>
 
                         <span class="license">
-                        <a href="https://www.apache.org/licenses/LICENSE-2.0"><span class="i18n" data-i18n="License">License</span></a></span>
+
+                        <!-- license href via setBaseTemplateListeners.js -->
+                        <a target="solinea_license" class="dynamic-license"><span class="i18n" data-i18n="License">License</span></a></span>
                     </div>
                     <!-- </div> -->
                 </footer>

--- a/goldstone/templates/login.html
+++ b/goldstone/templates/login.html
@@ -71,10 +71,10 @@ limitations under the License.
                         <span class="version">Version: 1.0.0-SNAPSHOT</span>
 
                         <span class="copyright"><strong>Copyright 2014-2016</strong>
-                         <a style="color:#fff" href="http://www.solinea.com">Solinea, Inc.</a></span>
+                         <a style="color:#fff" target="solinea_info" href="http://www.solinea.com">Solinea, Inc.</a></span>
 
                         <span class="license">
-                        <a style="color:#fff" href="https://www.apache.org/licenses/LICENSE-2.0">License</a></span>
+                        <a style="color:#fff" target="solinea_license" href="https://www.apache.org/licenses/LICENSE-2.0">License</a></span>
                     </div>
                 </div>
             </footer>


### PR DESCRIPTION
updates license link at bottom of page to point to proprietary license when on compliance pages.

to test: pull branch, check license link against compliance and other pages.

implemented:
- `license` link opens license in new tab
- `solinea, inc` link opens solinea.com in new tab
- unique `target` refs ensure that only a single external tab will open per-click on the `solinea, inc` or `license` links.

closes https://github.com/Solinea/goldstone-compliance/issues/45