### PR TITLE
made including of docs url dependent on debug setting

### DIFF
--- a/goldstone/settings/base.py
+++ b/goldstone/settings/base.py
@@ -287,8 +287,8 @@ REST_FRAMEWORK = {
 
 # Settings for Django REST Swagger.
 SWAGGER_SETTINGS = {
-    'api_version': "3.0",
-    "info": {"title": "Goldstone",
+    'api_version': "1",
+    "info": {"title": "Goldstone Server",
              "description":
              "Goldstone is a monitoring, management and analytics platform for"
              " operating OpenStack clouds.",

--- a/goldstone/urls.py
+++ b/goldstone/urls.py
@@ -23,13 +23,8 @@ from goldstone.views import RouterView
 
 admin.autodiscover()
 
-# API documentation.
-urlpatterns = patterns(
-    '',
-    url(r'^docs/', include("rest_framework_swagger.urls")))
-
 # API.
-urlpatterns += patterns(
+urlpatterns = patterns(
     '',
     url(r'^accounts/', include("goldstone.accounts.urls")),
     url(r'^admin/', include(admin.site.urls)),
@@ -59,3 +54,8 @@ urlpatterns += staticfiles_urlpatterns()
 # if the compliance module is here, let's bring it its URLs.
 if 'goldstone.compliance' in settings.INSTALLED_APPS:
     urlpatterns += url(r'^compliance/', include("goldstone.compliance.urls")),
+
+if settings.DEBUG:
+    # API documentation.
+    urlpatterns += url(r'^docs/', include("rest_framework_swagger.urls")),
+


### PR DESCRIPTION
To test, you can run in development mode normally, and see that http://localhost:8000/docs/ exists, then shut down, export GS_DEBUG=False, start up again and see that you get a 404 from the same link.