### PR TITLE
Add Makefile targets to run and compile desktop app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ ChangeLog
 # packaging
 rpm_packaging/temp/
 rpm_packaging/pkg/
+
+# desktop binary
+Goldstone-darwin-x64

--- a/Makefile
+++ b/Makefile
@@ -164,5 +164,5 @@ run-desktop:
 
 build-desktop:
 	cp -rv node_modules desktop/node_modules
-	./node_modules/.bin/electron-packager desktop/ Goldstone --overwrite --platform=darwin --arch=x64 --version=0.36.9 --icon=desktop/Icon.icns
+	./node_modules/.bin/electron-packager desktop/ Goldstone --overwrite --platform=darwin --arch=x64 --version=0.36.9 --icon=desktop/Icon.icns --app-version $(PKGVER) --ignore 'grunt*'
 	rm -rf desktop/node_modules

--- a/Makefile
+++ b/Makefile
@@ -158,3 +158,11 @@ test:
 cover:
 	coverage run --source='./goldstone' --omit='./goldstone/settings/*,*/test*' \
 		manage.py test goldstone --settings=goldstone.settings.docker_dev
+
+run-desktop:
+	./node_modules/.bin/electron desktop/
+
+build-desktop:
+	cp -rv node_modules desktop/node_modules
+	./node_modules/.bin/electron-packager desktop/ Goldstone --overwrite --platform=darwin --arch=x64 --version=0.36.9 --icon=desktop/Icon.icns
+	rm -rf desktop/node_modules

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,9 @@ run-desktop:
 	./node_modules/.bin/electron desktop/
 
 build-desktop:
-	cp -rv node_modules desktop/node_modules
-	./node_modules/.bin/electron-packager desktop/ Goldstone --overwrite --platform=darwin --arch=x64 --version=0.36.9 --icon=desktop/Icon.icns --app-version $(PKGVER) --ignore 'grunt*'
+	@echo "copying libraries to build directory ..."
+	cp -r node_modules desktop/node_modules
+	@echo "compiling mac application ..."
+	./node_modules/.bin/electron-packager desktop/ Goldstone --overwrite --platform=darwin --arch=x64 --version=0.37.2 --icon=desktop/Icon.icns --app-version $(PKGVER) --ignore 'grunt*|karma*|casper'
 	rm -rf desktop/node_modules
+	@echo "done."

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "casperjs": "1.1.0-beta3",
     "chai": "^3.5.0",
     "d3": "^3.5.16",
-    "electron-prebuilt": "^0.36.9",
+    "electron-prebuilt": "^0.37.2",
     "electron-packager": "^5.1.0",
     "grunt": "0.4.5",
     "grunt-casperjs": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "chai": "^3.5.0",
     "d3": "^3.5.16",
     "electron-prebuilt": "^0.36.9",
+    "electron-packager": "^5.1.0",
     "grunt": "0.4.5",
     "grunt-casperjs": "2.1.0",
     "grunt-contrib-clean": "^1.0.0",


### PR DESCRIPTION
adds electron-packager and Makefile target (`make run-desktop` and `make build-desktop`) to run and create goldstone desktop application.