### PR TITLE
start_local_env.sh should does the right thing

### DIFF
--- a/bin/start_local_celery.sh
+++ b/bin/start_local_celery.sh
@@ -1,18 +1,30 @@
 #!/bin/bash
 
-cd ${PROJECT_HOME}/goldstone-server
-. docker/config/goldstone-dev.env
-cat docker/config/goldstone-dev.env | sed -e '/^[#]/d' -e '/^$/d' | cut -f1 -d'=' | while read v 
-do  
+#
+# load up the standard goldstone environment vars
+#
+
+TOP_DIR=${GS_PROJ_TOP_DIR:-${PROJECT_HOME}/goldstone-server}
+cd $TOP_DIR 
+
+
+cat docker/config/goldstone-dev.env | sed -e '/^[#]/d' -e '/^$/d' > /var/tmp/gsenv
+while read v; do 
     export $v
-done
+done < /var/tmp/gsenv
+rm /var/tmp/gsenv
+
+
 export ENVDIR=${HOME}/.virtualenvs/goldstone-server
 export APPDIR=${ENVDIR}
-export GS_DB_HOST=127.0.0.1
 export DJANGO_SETTINGS_MODULE=goldstone.settings.local_dev
+export GOLDSTONE_REDIS_HOST=127.0.0.1
 export GS_LOCAL_DEV=true
-export GS_DEV_DJANGO_PORT=8001
-export GS_START_RUNSERVER=false
-export CELERY_BG=false
-. docker/goldstone-base/docker-entrypoint.sh
+python manage.py migrate --noinput
+python manage.py loaddata $(find goldstone -regex '.*/fixtures/.*' | xargs)
+python manage.py collectstatic  --noinput
+python post_install.py
+exec celery worker --app goldstone --queues default --beat --purge \
+            --workdir ${TOP_DIR} --config ${DJANGO_SETTINGS_MODULE} \
+            --without-heartbeat --loglevel=${CELERY_LOGLEVEL} -s /var/tmp/celerybeat-schedule
 

--- a/post_install.py
+++ b/post_install.py
@@ -215,10 +215,6 @@ def docker_install():
     OS_AUTH_URL (default: http://172.24.4.100:5000/v2.0/)
 
     """
-    # test to see that this really is a docker container.
-    if not os.path.isfile('/.dockerinit'):
-        print(red('This Does not appear to be a docker container. Exiting.'))
-        exit(1)
 
     # pull params out of the environment
     django_admin_user = os.environ.get('DJANGO_ADMIN_USER', 'admin')
@@ -233,8 +229,7 @@ def docker_install():
     stack_tenant = os.environ.get('OS_TENANT_NAME')
     stack_user = os.environ.get('OS_USERNAME')
     stack_password = os.environ.get('OS_PASSWORD')
-    stack_auth_url = os.environ.get(
-        'OS_AUTH_URL')
+    stack_auth_url = os.environ.get('OS_AUTH_URL', None)
 
     print(green("Setting up Django admin account."))
     django_admin_init(
@@ -249,6 +244,13 @@ def docker_install():
         gs_tenant_admin,
         gs_tenant_admin_password
     )
+
+    django_settings = os.environ.get('DJANGO_SETTINGS_MODULE', None)
+    print(green("DJANGO_SETTINGS_MODULE = %s" % django_settings))
+    print(green("OS_TENANT_NAME = %s" % stack_tenant))
+    print(green("OS_USERNAME = %s" % stack_user))
+    print(green("OS_PASSWORD = %s" % stack_password))
+    print(green("OS_AUTH_URL = %s" % stack_auth_url))
 
     print(green("Initializing connection to OpenStack cloud."))
     cloud_init(


### PR DESCRIPTION
You should not need to run `start_dev_env.sh` to prime the system now.  To test:

```
workon goldstone-server
eval $(docker-machine env default)
docker rm -f $(docker ps -qa)
docker rmi -f $(docker images | grep goldstone | awk '{print $3}')
bin/start_local_env.sh
```

You should end up with a running celery environment in the bottom tmux window and be ready to fire up the app server in your favorite IDE.