### PR TITLE
Issue 460 - create saved searches and alerts for canary feature

### DIFF
--- a/goldstone/core/fixtures/core_initial_data.yaml
+++ b/goldstone/core/fixtures/core_initial_data.yaml
@@ -496,7 +496,7 @@
         owner: core
         index_prefix: internal-*
         doc_type: canary
-        timestamp_field: '@timestamp'
+        timestamp_field: 'ingest_time'
         protected: true
         query: '{
    "query": {
@@ -529,7 +529,7 @@
         owner: core
         index_prefix: internal-*
         doc_type: canary
-        timestamp_field: '@timestamp'
+        timestamp_field: 'ingest_time'
         protected: true
         query: '{
    "query": {
@@ -553,7 +553,7 @@
         owner: core
         index_prefix: internal-*
         doc_type: canary
-        timestamp_field: '@timestamp'
+        timestamp_field: 'ingest_time'
         protected: true
         query: '{
    "query": {
@@ -576,7 +576,7 @@
       },
       "per_interval": {
          "date_histogram": {
-            "field": "@timestamp",
+            "field": "ingest_time",
             "interval": "1d",
             "min_doc_count": 0
          },

--- a/goldstone/core/fixtures/core_initial_data.yaml
+++ b/goldstone/core/fixtures/core_initial_data.yaml
@@ -505,7 +505,7 @@
             {
                "range": {
                   "elapsed": {
-                     "gte": 50
+                     "gte": 60
                   }
                }
             }
@@ -537,7 +537,7 @@
          "must": [
             {
                "term": {
-                  "result": "false"
+                  "result": false
                }
             }
          ]
@@ -557,7 +557,7 @@
         protected: true
         query: '{
   "query": {
-     "match_all": {}
+     "match_all": {}   ### put in clause "testflight"
   },
   "aggs": {
      "all_results": {

--- a/goldstone/core/fixtures/core_initial_data.yaml
+++ b/goldstone/core/fixtures/core_initial_data.yaml
@@ -471,3 +471,114 @@
         name: service status UP
         description: 'one or more services have changed status to UP'
         search: de730aab-e0f9-40c7-81c0-4289ddb67e96
+
+  - model: core.AlertDefinition
+    pk: f053951a-2834-43e1-a5dc-a6faf36260ed
+    fields:
+        name: service status UP
+        description: 'one or more services have changed status to UP'
+        search: de730aab-e0f9-40c7-81c0-4289ddb67e96
+
+
+
+  - model: core.AlertDefinition
+    pk: adceb329-6760-4e2b-a34e-1d4a49c5b53e
+    fields:
+        name: elapsed time exceeds limit
+        description: 'a canary test has exceeded the elaspsed time limit'
+        search: 836717be-a1ac-4ab7-92ed-46923abcc383
+
+  - model: core.SavedSearch
+    pk: 836717be-a1ac-4ab7-92ed-46923abcc383
+    fields:
+        name: canary elapsed time query
+        description: 'Goldstone Canary elapsed times exceeding a maximum.'
+        owner: core
+        index_prefix: internal-*
+        doc_type: canary
+        timestamp_field: '@timestamp'
+        protected: true
+        query: '{
+   "query": {
+      "bool": {
+         "must": [
+            {
+               "range": {
+                  "elapsed": {
+                     "gte": 50
+                  }
+               }
+            }
+         ]
+      }
+   }
+}'
+
+  - model: core.AlertDefinition
+    pk: d5663d34-46fa-4302-bd76-3a8942525c93
+    fields:
+        name: canary test returns false
+        description: 'a canary test has returned false'
+        search: b233986f-ebd5-4815-8c89-0b3f2a81445e
+
+  - model: core.SavedSearch
+    pk: b233986f-ebd5-4815-8c89-0b3f2a81445e
+    fields:
+        name: canary result query
+        description: 'Goldstone Canary test that returns false.'
+        owner: core
+        index_prefix: internal-*
+        doc_type: canary
+        timestamp_field: '@timestamp'
+        protected: true
+        query: '{
+   "query": {
+      "bool": {
+         "must": [
+            {
+               "term": {
+                  "result": "false"
+               }
+            }
+         ]
+      }
+   }
+}'
+
+  - model: core.SavedSearch
+    pk: 139851f2-1329-4826-9c70-c154a6c102f2
+    fields:
+        name: canary metric
+        description: 'Goldstone Canary metrics.'
+        owner: core
+        index_prefix: internal-*
+        doc_type: canary
+        timestamp_field: '@timestamp'
+        protected: true
+        query: '{
+  "query": {
+     "match_all": {}
+  },
+  "aggs": {
+     "all_results": {
+        "terms": {
+	       "field": "result",
+	       "size": "0"
+	    }
+	  }
+      "per_interval": {
+         "date_histogram": {
+            "field": "@timestamp",
+            "interval": "1d",
+            "min_doc_count": 0
+         },
+         "aggs": {
+            "statistics": {
+               "stats": {
+                  "field": "elapsed"
+               }
+            }
+         }
+      }
+   }
+}'

--- a/goldstone/core/fixtures/core_initial_data.yaml
+++ b/goldstone/core/fixtures/core_initial_data.yaml
@@ -561,7 +561,7 @@
          "must": [
             {
                "term": {
-                  "facility": "testflight"
+                  "short_message": "testflight"
                }
             }
          ]

--- a/goldstone/core/fixtures/core_initial_data.yaml
+++ b/goldstone/core/fixtures/core_initial_data.yaml
@@ -556,16 +556,24 @@
         timestamp_field: '@timestamp'
         protected: true
         query: '{
-  "query": {
-     "match_all": {}   ### put in clause "testflight"
-  },
-  "aggs": {
-     "all_results": {
-        "terms": {
-	       "field": "result",
+   "query": {
+      "bool": {
+         "must": [
+            {
+               "term": {
+                  "facility": "testflight"
+               }
+            }
+         ]
+      }
+   },
+   "aggs": {
+      "all_results": {
+         "terms": {
+	    "field": "result",
 	       "size": "0"
-	    }
-	  }
+	 }
+      },
       "per_interval": {
          "date_histogram": {
             "field": "@timestamp",

--- a/goldstone/core/fixtures/core_initial_data.yaml
+++ b/goldstone/core/fixtures/core_initial_data.yaml
@@ -485,7 +485,7 @@
     pk: adceb329-6760-4e2b-a34e-1d4a49c5b53e
     fields:
         name: elapsed time exceeds limit
-        description: 'a canary test has exceeded the elaspsed time limit'
+        description: 'a canary test has exceeded the elapsed time limit'
         search: 836717be-a1ac-4ab7-92ed-46923abcc383
 
   - model: core.SavedSearch

--- a/goldstone/core/tests_models.py
+++ b/goldstone/core/tests_models.py
@@ -117,7 +117,6 @@ class ModelTests(TestCase):
         self.assertIsInstance(start1, datetime)
         self.assertIsInstance(end1, datetime)
         self.assertWithinASecond(start1, end1)
-        self.assertNotEqual(search._doc_type, [])
 
         def find_range_dict(a, z):
             """Helper function that extracts the dict with range key."""

--- a/goldstone/core/urls.py
+++ b/goldstone/core/urls.py
@@ -58,4 +58,6 @@ urlpatterns += patterns(
         {'get': 'results'}), {'uuid': '7906893c-16dc-4ab3-96e0-8f0054bd4cc1'}),
     url(r'^metrics/', SavedSearchViewSet.as_view(
         {'get': 'results'}), {'uuid': 'a3f34f00-967b-40a2-913e-ba10afdd611b'}),
+    url(r'^canary/', SavedSearchViewSet.as_view(
+        {'get': 'results'}), {'uuid': '139851f2-1329-4826-9c70-c154a6c102f2'}),
 )


### PR DESCRIPTION
Added the following alerts and searches for canary:

1) search for testflight records with aggregation to graph elapsed time
2) alert for all canary records with result != true
3) search for testflight with a specific uuid (accept uuid as a parameter)