### PR TITLE
Issue 463 - new alerts not being generated or not making it to client

### DIFF
--- a/goldstone/core/fixtures/core_initial_data.yaml
+++ b/goldstone/core/fixtures/core_initial_data.yaml
@@ -337,7 +337,7 @@
          "must": [
             {
                "match_phrase": {
-                  "message": {
+                  "full_message": {
                      "query": "service status update discovered",
                      "slop": 10
                   }
@@ -370,14 +370,14 @@
          "must": [
             {
                "match_phrase": {
-                  "message": {
+                  "full_message": {
                      "query": "service status update"
                   }
                }
             },
             {
                "match_phrase": {
-                  "message": {
+                  "full_message": {
                      "query": "to down"
                   }
                }
@@ -409,14 +409,14 @@
          "must": [
             {
                "match_phrase": {
-                  "message": {
+                  "full_message": {
                      "query": "service status update"
                   }
                }
             },
             {
                "match_phrase": {
-                  "message": {
+                  "full_message": {
                      "query": "to unknown"
                   }
                }

--- a/goldstone/core/fixtures/core_initial_data.yaml
+++ b/goldstone/core/fixtures/core_initial_data.yaml
@@ -448,14 +448,14 @@
          "must": [
             {
                "match_phrase": {
-                  "message": {
+                  "full_message": {
                      "query": "service status update"
                   }
                }
             },
             {
                "match_phrase": {
-                  "message": {
+                  "full_message": {
                      "query": "to up"
                   }
                }


### PR DESCRIPTION
Updated the internal-* saved searches to match on 'full_message' field in core/fixtures/core_initial_data.yaml and compliance/fixtures/core_initial_data.yaml.