### PR TITLE
omit microservice images from version bump

### DIFF
--- a/bin/bump_images.sh
+++ b/bin/bump_images.sh
@@ -73,35 +73,20 @@ fi
 # We will replace the version with our $TAG, and if any files have changed, 
 # exit with a non-zero code to make the hook fail.
 for file in "${dockerfile_list[@]}" ; do
-    cat $file | sed -e "s/^\(FROM solinea\/goldstone-.*:\).*$/\1${TAG}/" > ${file}.new
-    RC=`diff $file $file.new`
-    if [[ $RC != 0 ]] ; then
-       mv ${file}.new $file
-    else
-       rm ${file}.new
-    fi
+    sed -i.bak -e "s/^\(FROM solinea\/goldstone-.*:\).*$/\1${TAG}/" ${file}
+    rm -f ${file}.bak
 done
 
 for file in "${composefile_list[@]}" ; do
-    cat $file | sed -e "/[[:space:]]*image:[[:space:]]*.*\/goldstone-svc-.*:.*$/b" \
-                    -e "s/^\([[:space:]]*image:[[:space:]]*solinea\/goldstone-.*:\).*$/\1${TAG}/" \
-                    -e "s/^\([[:space:]]*image:[[:space:]]*gs-docker-ent.bintray.io\/goldstone-.*:\).*$/\1${TAG}/" > ${file}.new
-    RC=`diff $file $file.new`
-    if [[ $RC != 0 ]] ; then
-       mv ${file}.new $file
-    else
-       rm ${file}.new
-    fi
+    sed -i.bak -e "/[[:space:]]*image:[[:space:]]*.*\/goldstone-svc-.*:.*$/b" \
+             -e "s/^\([[:space:]]*image:[[:space:]]*solinea\/goldstone-.*:\).*$/\1${TAG}/" \
+             -e "s/^\([[:space:]]*image:[[:space:]]*gs-docker-ent.bintray.io\/goldstone-.*:\).*$/\1${TAG}/" ${file}
+    rm -f ${file}.bak
 done
 
 for file in "${settingsfile_list[@]}" ; do
-    cat $file | sed -e "s/GOLDSTONE_VERSION = \('\).*\('\)/GOLDSTONE_VERSION = \1${TAG}\2/" > ${file}.new
-    RC=`diff $file $file.new`
-    if [[ $RC != 0 ]] ; then
-       mv ${file}.new $file
-    else
-       rm ${file}.new
-    fi
+    sed -i.bak -e "s/GOLDSTONE_VERSION = \('\).*\('\)/GOLDSTONE_VERSION = \1${TAG}\2/" ${file}
+    rm -f ${file}.bak
 done
 
 git status --short

--- a/bin/bump_images.sh
+++ b/bin/bump_images.sh
@@ -83,7 +83,8 @@ for file in "${dockerfile_list[@]}" ; do
 done
 
 for file in "${composefile_list[@]}" ; do
-    cat $file | sed -e "s/^\([[:space:]]*image:[[:space:]]*solinea\/goldstone-.*:\).*$/\1${TAG}/" \
+    cat $file | sed -e "/[[:space:]]*image:[[:space:]]*.*\/goldstone-svc-.*:.*$/b" \
+                    -e "s/^\([[:space:]]*image:[[:space:]]*solinea\/goldstone-.*:\).*$/\1${TAG}/" \
                     -e "s/^\([[:space:]]*image:[[:space:]]*gs-docker-ent.bintray.io\/goldstone-.*:\).*$/\1${TAG}/" > ${file}.new
     RC=`diff $file $file.new`
     if [[ $RC != 0 ]] ; then

--- a/bin/start_dev_env.sh
+++ b/bin/start_dev_env.sh
@@ -125,8 +125,9 @@ fi
 
 # these need to exist in order to build
 mkdir docker/goldstone-app/goldstone-server 2> /dev/null
-mkdir docker/goldstone-app-e/goldstone-server |2> /dev/null
-mkdir docker/goldstone-task/goldstone-server |2> /dev/null
+mkdir docker/goldstone-app-e/goldstone-server 2> /dev/null
+mkdir docker/goldstone-task/goldstone-server 2> /dev/null
+mkdir docker/goldstone-task-e/goldstone-server 2> /dev/null
 
 docker-compose -f ${COMPOSE_FILE} up &
 COMPOSE_PID=$!


### PR DESCRIPTION
To test:

* Check out the branch
* Run `bin/bump_images.sh`
* Look at the diffs and you should see changed versions for all image references except goldstone-svc-canary, which should be pinned at latest

**Please don't check in the files with changed versions**

@lexjacobs @vichargrave 