### PR TITLE
Start dev env improvments

### DIFF
--- a/bin/build_images.sh
+++ b/bin/build_images.sh
@@ -84,7 +84,7 @@ else
    echo "Building tag: $TAG"
 fi
 
-if [[ ${DOCKER_VM} != "false" ]] ; then
+if [[ ${DOCKER_VM} != "none" ]] ; then
     docker-machine start ${DOCKER_VM}
     eval "$(docker-machine env ${DOCKER_VM})"
 fi

--- a/bin/push_images.sh
+++ b/bin/push_images.sh
@@ -40,7 +40,7 @@ for arg in "$@" ; do
     esac
 done
 
-if [[ ${DOCKER_VM} != "false" ]] ; then
+if [[ ${DOCKER_VM} != "none" ]] ; then
     docker-machine start ${DOCKER_VM}
     eval "$(docker-machine env ${DOCKER_VM})"
 fi

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -18,14 +18,14 @@ version: '2'
 services:
   # Database Container
   gsdb:
-    image: solinea/goldstone-db:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-db:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     env_file: ./config/goldstone-test.env
     ports:
       - "5432:5432"
 
   # Logstash Container
   gslog:
-    image: solinea/goldstone-log:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-log:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     ports:
       - "5514:5514"
       - "5515:5515"
@@ -36,14 +36,14 @@ services:
 
   # Elasticsearch Container
   gssearch:
-    image: solinea/goldstone-search:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-search:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     ports:
       - "9200:9200"
       - "9300:9300"
 
   # Celery Task Queue Container
   gstaskq:
-    image: solinea/goldstone-task-queue:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-task-queue:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     ports:
       - "6379:6379"
 
@@ -51,7 +51,7 @@ services:
   # Celery container
   #
   gstask:
-    image: solinea/goldstone-task:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-task:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     env_file: ./config/goldstone-test.env
     links:
       - gsdb

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -18,14 +18,14 @@ version: '2'
 services:
   # Database Container
   gsdb:
-    image: solinea/goldstone-db:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-db:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     env_file: ./config/goldstone-test.env
     ports:
       - "5432:5432"
 
   # Logstash Container
   gslog:
-    image: solinea/goldstone-log:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-log:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     ports:
       - "5514:5514"
       - "5515:5515"
@@ -36,14 +36,14 @@ services:
 
   # Elasticsearch Container
   gssearch:
-    image: solinea/goldstone-search:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-search:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     ports:
       - "9200:9200"
       - "9300:9300"
 
   # Celery Task Queue Container
   gstaskq:
-    image: solinea/goldstone-task-queue:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-task-queue:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     ports:
       - "6379:6379"
 
@@ -51,7 +51,7 @@ services:
   # Celery container
   #
   gstask:
-    image: solinea/goldstone-task:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-task:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     env_file: ./config/goldstone-test.env
     links:
       - gsdb

--- a/docker/docker-compose-enterprise.yml
+++ b/docker/docker-compose-enterprise.yml
@@ -19,7 +19,7 @@ services:
 
   # Goldstone Proxy & Static
   gsweb:
-    image: solinea/goldstone-web:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-web:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     ports:
       - "8443:8443"
     links:
@@ -32,7 +32,7 @@ services:
 
   # Goldstone Server Container
   gsapp:
-    image: gs-docker-ent.bintray.io/goldstone-app-e:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: gs-docker-ent.bintray.io/goldstone-app-e:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     env_file: ./config/goldstone-prod.env
     ports:
       - "8000:8000"
@@ -49,7 +49,7 @@ services:
 
   # Database Container
   gsdb:
-    image: solinea/goldstone-db:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-db:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     env_file: ./config/goldstone-prod.env
     volumes:
       - /var/lib/goldstone/sql_data:/var/lib/postgresql/data
@@ -63,7 +63,7 @@ services:
 
   # Logstash Container
   gslog:
-    image: solinea/goldstone-log:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-log:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     ports:
       - "5514:5514"
       - "5515:5515"
@@ -79,7 +79,7 @@ services:
 
   # Elasticsearch Container
   gssearch:
-    image: solinea/goldstone-search:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-search:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -93,7 +93,7 @@ services:
 
   # Celery Task Queue Container
   gstaskq:
-    image: solinea/goldstone-task-queue:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-task-queue:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     ports:
       - "6379:6379"
     logging:
@@ -106,7 +106,7 @@ services:
   # Celery container
   #
   gstask:
-    image: gs-docker-ent.bintray.io/goldstone-task-e:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: gs-docker-ent.bintray.io/goldstone-task-e:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     env_file: ./config/goldstone-prod.env
     links:
       - gsdb

--- a/docker/docker-compose-enterprise.yml
+++ b/docker/docker-compose-enterprise.yml
@@ -19,7 +19,7 @@ services:
 
   # Goldstone Proxy & Static
   gsweb:
-    image: solinea/goldstone-web:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-web:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     ports:
       - "8443:8443"
     links:
@@ -32,7 +32,7 @@ services:
 
   # Goldstone Server Container
   gsapp:
-    image: gs-docker-ent.bintray.io/goldstone-app-e:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: gs-docker-ent.bintray.io/goldstone-app-e:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     env_file: ./config/goldstone-prod.env
     ports:
       - "8000:8000"
@@ -49,7 +49,7 @@ services:
 
   # Database Container
   gsdb:
-    image: solinea/goldstone-db:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-db:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     env_file: ./config/goldstone-prod.env
     volumes:
       - /var/lib/goldstone/sql_data:/var/lib/postgresql/data
@@ -63,7 +63,7 @@ services:
 
   # Logstash Container
   gslog:
-    image: solinea/goldstone-log:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-log:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     ports:
       - "5514:5514"
       - "5515:5515"
@@ -79,7 +79,7 @@ services:
 
   # Elasticsearch Container
   gssearch:
-    image: solinea/goldstone-search:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-search:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -93,7 +93,7 @@ services:
 
   # Celery Task Queue Container
   gstaskq:
-    image: solinea/goldstone-task-queue:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-task-queue:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     ports:
       - "6379:6379"
     logging:
@@ -106,7 +106,7 @@ services:
   # Celery container
   #
   gstask:
-    image: gs-docker-ent.bintray.io/goldstone-task-e:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: gs-docker-ent.bintray.io/goldstone-task-e:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     env_file: ./config/goldstone-prod.env
     links:
       - gsdb

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   # Goldstone Proxy & Static
   gsweb:
-    image: solinea/goldstone-web:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-web:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     ports:
       - "8443:8443"
     links:
@@ -32,7 +32,7 @@ services:
 
   # Goldstone Server Container
   gsapp:
-    image: solinea/goldstone-app:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-app:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     env_file: ./config/goldstone-prod.env
     ports:
       - "8000:8000"
@@ -49,7 +49,7 @@ services:
 
   # Database Container
   gsdb:
-    image: solinea/goldstone-db:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-db:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     env_file: ./config/goldstone-prod.env
     volumes:
       - /var/lib/goldstone/sql_data:/var/lib/postgresql/data
@@ -63,7 +63,7 @@ services:
 
   # Logstash Container
   gslog:
-    image: solinea/goldstone-log:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-log:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     ports:
       - "5514:5514"
       - "5515:5515"
@@ -79,7 +79,7 @@ services:
 
   # Elasticsearch Container
   gssearch:
-    image: solinea/goldstone-search:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-search:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -93,7 +93,7 @@ services:
 
   # Celery Task Queue Container
   gstaskq:
-    image: solinea/goldstone-task-queue:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-task-queue:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     ports:
       - "6379:6379"
     logging:
@@ -106,7 +106,7 @@ services:
   # Celery container
   #
   gstask:
-    image: solinea/goldstone-task:1.1.1-SNAPSHOT.147.gee0bca5.develop
+    image: solinea/goldstone-task:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
     env_file: ./config/goldstone-prod.env
     links:
       - gsdb

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   # Goldstone Proxy & Static
   gsweb:
-    image: solinea/goldstone-web:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-web:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     ports:
       - "8443:8443"
     links:
@@ -32,7 +32,7 @@ services:
 
   # Goldstone Server Container
   gsapp:
-    image: solinea/goldstone-app:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-app:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     env_file: ./config/goldstone-prod.env
     ports:
       - "8000:8000"
@@ -49,7 +49,7 @@ services:
 
   # Database Container
   gsdb:
-    image: solinea/goldstone-db:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-db:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     env_file: ./config/goldstone-prod.env
     volumes:
       - /var/lib/goldstone/sql_data:/var/lib/postgresql/data
@@ -63,7 +63,7 @@ services:
 
   # Logstash Container
   gslog:
-    image: solinea/goldstone-log:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-log:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     ports:
       - "5514:5514"
       - "5515:5515"
@@ -79,7 +79,7 @@ services:
 
   # Elasticsearch Container
   gssearch:
-    image: solinea/goldstone-search:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-search:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -93,7 +93,7 @@ services:
 
   # Celery Task Queue Container
   gstaskq:
-    image: solinea/goldstone-task-queue:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-task-queue:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     ports:
       - "6379:6379"
     logging:
@@ -106,7 +106,7 @@ services:
   # Celery container
   #
   gstask:
-    image: solinea/goldstone-task:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+    image: solinea/goldstone-task:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
     env_file: ./config/goldstone-prod.env
     links:
       - gsdb

--- a/docker/goldstone-app-e/Dockerfile
+++ b/docker/goldstone-app-e/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM solinea/goldstone-base:1.1.1-SNAPSHOT.147.gee0bca5.develop
+FROM solinea/goldstone-base:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
 
 MAINTAINER Luke Heidecke <luke@solinea.com>
 

--- a/docker/goldstone-app-e/Dockerfile
+++ b/docker/goldstone-app-e/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM solinea/goldstone-base:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+FROM solinea/goldstone-base:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
 
 MAINTAINER Luke Heidecke <luke@solinea.com>
 

--- a/docker/goldstone-app/Dockerfile
+++ b/docker/goldstone-app/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM solinea/goldstone-base:1.1.1-SNAPSHOT.147.gee0bca5.develop
+FROM solinea/goldstone-base:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
 
 MAINTAINER Luke Heidecke <luke@solinea.com>
 

--- a/docker/goldstone-app/Dockerfile
+++ b/docker/goldstone-app/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM solinea/goldstone-base:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+FROM solinea/goldstone-base:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
 
 MAINTAINER Luke Heidecke <luke@solinea.com>
 

--- a/docker/goldstone-task-e/Dockerfile
+++ b/docker/goldstone-task-e/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM solinea/goldstone-base:1.1.1-SNAPSHOT.147.gee0bca5.develop
+FROM solinea/goldstone-base:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
 
 MAINTAINER Luke Heidecke <luke@solinea.com>
 

--- a/docker/goldstone-task-e/Dockerfile
+++ b/docker/goldstone-task-e/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM solinea/goldstone-base:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+FROM solinea/goldstone-base:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
 
 MAINTAINER Luke Heidecke <luke@solinea.com>
 

--- a/docker/goldstone-task/Dockerfile
+++ b/docker/goldstone-task/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM solinea/goldstone-base:1.1.1-SNAPSHOT.147.gee0bca5.develop
+FROM solinea/goldstone-base:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
 
 MAINTAINER Luke Heidecke <luke@solinea.com>
 

--- a/docker/goldstone-task/Dockerfile
+++ b/docker/goldstone-task/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM solinea/goldstone-base:1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments
+FROM solinea/goldstone-base:1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments
 
 MAINTAINER Luke Heidecke <luke@solinea.com>
 

--- a/goldstone/settings/base.py
+++ b/goldstone/settings/base.py
@@ -24,7 +24,7 @@ from celery.schedules import crontab
 from kombu import Exchange, Queue
 
 # this version should be managed by the bump_version.sh script
-GOLDSTONE_VERSION = '1.1.1-SNAPSHOT.147.gee0bca5.develop'
+GOLDSTONE_VERSION = '1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments'
 
 CURRENT_DIR = os.path.dirname(__file__)
 TEMPLATE_DIRS = (os.path.join(CURRENT_DIR, '../templates'),)

--- a/goldstone/settings/base.py
+++ b/goldstone/settings/base.py
@@ -24,7 +24,7 @@ from celery.schedules import crontab
 from kombu import Exchange, Queue
 
 # this version should be managed by the bump_version.sh script
-GOLDSTONE_VERSION = '1.1.1-SNAPSHOT.153.g0535c4d.start_dev_env_improvments'
+GOLDSTONE_VERSION = '1.1.1-SNAPSHOT.154.g2cec752.start_dev_env_improvments'
 
 CURRENT_DIR = os.path.dirname(__file__)
 TEMPLATE_DIRS = (os.path.join(CURRENT_DIR, '../templates'),)

--- a/goldstone/settings/local_dev.py
+++ b/goldstone/settings/local_dev.py
@@ -21,12 +21,12 @@ TEMPLATE_DEBUG = bool(os.environ.get('GS_TEMPLATE_DEBUG', True))
 
 STATIC_ROOT = os.path.join(os.getcwd(), 'static')
 
-DATABASES['default']['HOST'] = '127.0.0.1'
-LOGGING['handlers']['graypy']['host'] = '127.0.0.1'
+DATABASES['default']['HOST'] = os.environ.get('GS_DOCKER_HOST', '127.0.0.1')
+LOGGING['handlers']['graypy']['host'] = os.environ.get('GS_DOCKER_HOST', '127.0.0.1')
 
 STATIC_ROOT = os.path.join(os.getcwd(),
                            'docker/goldstone-web/static')
 STATIC_URL = '/static/'
 
-ES_HOST = '127.0.0.1'
+ES_HOST = os.environ.get('GS_DOCKER_HOST', '127.0.0.1')
 ES_SERVER = {'hosts': [ES_HOST + ":" + ES_PORT]}


### PR DESCRIPTION
Bin scripts that work with native docker on mac, hoping that they also work with Unbuntu dev environments.  

For testing, @lexjacobs would be nice to confirm that it doesn't break start_dev_env on Mac with Virtualbox setup.