### PR TITLE
Removes type column from api call browser.

### DIFF
--- a/client/js/views/apiBrowserDataTableView.js
+++ b/client/js/views/apiBrowserDataTableView.js
@@ -93,12 +93,7 @@ var ApiBrowserDataTableView = DataTableBaseView.extend({
                     "data": "_source.component",
                     "targets": 7,
                     "sortable": true
-                }, {
-                    "data": "_source.type",
-                    "targets": 8,
-                    "sortable": true
                 }
-
             ],
             "serverSide": true,
             "ajax": {
@@ -140,7 +135,6 @@ var ApiBrowserDataTableView = DataTableBaseView.extend({
                         5: 'response_time',
                         6: 'response_length',
                         7: 'component',
-                        8: 'type',
                     };
                     var ascDec = {
                         asc: '',
@@ -211,7 +205,6 @@ var ApiBrowserDataTableView = DataTableBaseView.extend({
         '<th><%=goldstone.contextTranslate(\'response time\', \'apibrowserdata\')%></th>' +
         '<th><%=goldstone.contextTranslate(\'length\', \'apibrowserdata\')%></th>' +
         '<th><%=goldstone.contextTranslate(\'component\', \'apibrowserdata\')%></th>' +
-        '<th><%=goldstone.contextTranslate(\'type\', \'apibrowserdata\')%></th>' +
         '</tr>'
     )
 });

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -4074,12 +4074,7 @@ var ApiBrowserDataTableView = DataTableBaseView.extend({
                     "data": "_source.component",
                     "targets": 7,
                     "sortable": true
-                }, {
-                    "data": "_source.type",
-                    "targets": 8,
-                    "sortable": true
                 }
-
             ],
             "serverSide": true,
             "ajax": {
@@ -4121,7 +4116,6 @@ var ApiBrowserDataTableView = DataTableBaseView.extend({
                         5: 'response_time',
                         6: 'response_length',
                         7: 'component',
-                        8: 'type',
                     };
                     var ascDec = {
                         asc: '',
@@ -4192,7 +4186,6 @@ var ApiBrowserDataTableView = DataTableBaseView.extend({
         '<th><%=goldstone.contextTranslate(\'response time\', \'apibrowserdata\')%></th>' +
         '<th><%=goldstone.contextTranslate(\'length\', \'apibrowserdata\')%></th>' +
         '<th><%=goldstone.contextTranslate(\'component\', \'apibrowserdata\')%></th>' +
-        '<th><%=goldstone.contextTranslate(\'type\', \'apibrowserdata\')%></th>' +
         '</tr>'
     )
 });


### PR DESCRIPTION
before:
<img width="1234" alt="screen shot 2016-04-22 at 1 41 32 pm" src="https://cloud.githubusercontent.com/assets/5633015/14754451/40af6f98-0890-11e6-80d5-602913bea40c.png">

after:
<img width="1228" alt="screen shot 2016-04-22 at 1 41 38 pm" src="https://cloud.githubusercontent.com/assets/5633015/14754450/40aab336-0890-11e6-9606-ffa24f8305e9.png">

closes #488 