### PR TITLE
Saved search viewer_enabled

### DIFF
--- a/client/js/preload/init.js
+++ b/client/js/preload/init.js
@@ -27,6 +27,10 @@ goldstone.init = function() {
     finally, authLogoutIcon prunes old unused keys in localStorage
     */
 
+    // set default error behavior of dataTables to throw
+    // a console error instead of raising a browser alert
+    $.fn.dataTable.ext.errMode = 'throw';
+
     goldstone.localStorageKeys = ['compliance', 'topology', 'userToken', 'userPrefs', 'rem'];
 
     goldstone.authLogoutIcon = new LogoutIcon();

--- a/client/js/views/savedSearchDataTableView.js
+++ b/client/js/views/savedSearchDataTableView.js
@@ -525,6 +525,10 @@ SavedSearchDataTableView = DataTableBaseView.extend({
         // hidden timestamp_field
         '<input name="timestamp_field" id="timestamp_field" hidden type="text" value="<%= this.form_timestamp_field %>">' +
 
+        // hidden viewer_enabled field
+        // client must submit 'true' otherwise server will default to false
+        '<input name="viewer_enabled" id="viewer_enabled" hidden type="text" value="true">' +
+
         // submit button
         '<button id="submit-create-button" type="submit"' +
         ' class="btn btn-default"><%=goldstone.contextTranslate(\'Submit Search\', \'savedsearch\')%></button> ' +

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -11379,6 +11379,10 @@ SavedSearchDataTableView = DataTableBaseView.extend({
         // hidden timestamp_field
         '<input name="timestamp_field" id="timestamp_field" hidden type="text" value="<%= this.form_timestamp_field %>">' +
 
+        // hidden viewer_enabled field
+        // client must submit 'true' otherwise server will default to false
+        '<input name="viewer_enabled" id="viewer_enabled" hidden type="text" value="true">' +
+
         // submit button
         '<button id="submit-create-button" type="submit"' +
         ' class="btn btn-default"><%=goldstone.contextTranslate(\'Submit Search\', \'savedsearch\')%></button> ' +

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -13079,6 +13079,10 @@ goldstone.init = function() {
     finally, authLogoutIcon prunes old unused keys in localStorage
     */
 
+    // set default error behavior of dataTables to throw
+    // a console error instead of raising a browser alert
+    $.fn.dataTable.ext.errMode = 'throw';
+
     goldstone.localStorageKeys = ['compliance', 'topology', 'userToken', 'userPrefs', 'rem'];
 
     goldstone.authLogoutIcon = new LogoutIcon();


### PR DESCRIPTION
Set client to send 'viewer_enabled=true' along with user-created saved search.
Otherwise server defaults to false, which results in user-created saved search not being visible.

Also modifies error handling of dataTables to throw via the console instead of raising an alert. All error reporting that was delivered via the alert is still intact in the console message, making a far less intrusive user experience.