### PR TITLE
Startup improvements

### DIFF
--- a/MANIFEST.in.oss
+++ b/MANIFEST.in.oss
@@ -19,4 +19,5 @@ prune docker
 prune rpm_packaging
 prune test
 prune goldstone/compliance
+prune goldstone/topology
 prune desktop

--- a/bin/setup_dev_env.sh
+++ b/bin/setup_dev_env.sh
@@ -9,7 +9,7 @@ CONFIGURE_VBOX=Y
 DOCKER_VM=
 
 function usage {
-    echo "Usage: $0 docker-vm=name|none [--shell-profile=filename] [--src-home=dirname] [--ova-download-dir=dirname] [--no-download-ova] [--delete-ova] [--no-configure-vbox]"
+    echo "Usage: $0 --docker-vm=name|none [--shell-profile=filename] [--src-home=dirname] [--ova-download-dir=dirname] [--no-download-ova] [--delete-ova] [--no-configure-vbox]"
 }
 
 for arg in "$@" ; do
@@ -60,11 +60,23 @@ export GS_PROJ_TOP_DIR=${SRC_HOME}/goldstone-server
 # 
 # install brew prerequisites
 #  (todo) this is very mac specific.  generalize for other platforms
-echo "$(tput setaf 2)Installing prerequisites$(tput sgr 0)"
-brew install python > /dev/null 2>&1 
-brew install git > /dev/null 2>&1
-brew install postgresql > /dev/null 2>&1
-brew install pyenv-virtualenvwrapper > /dev/null 2>&1
+OS_VARIANT=`uname -s`
+BREW_INSTALLED=`which brew`
+echo "OS_VARIANT = $OS_VARIANT"
+echo "BREW_INSTALLED = $BREW_INSTALLED"
+if [[ $OS_VARIANT == "Darwin" && $BREW_INSTALLED == /* ]] ; then
+    echo "$(tput setaf 2)Installing prerequisites$(tput sgr 0)"
+    brew install python > /dev/null 2>&1 
+    brew install git > /dev/null 2>&1
+    brew install postgresql > /dev/null 2>&1
+    brew install pyenv-virtualenvwrapper > /dev/null 2>&1
+else
+    echo "$(tput setaf 3)This does not appear to be OSX.  Please install these manually when this script finishes:$(tput sgr 0)"
+    echo "$(tput setaf 3)    - git$(tput sgr 0)"
+    echo "$(tput setaf 3)    - python$(tput sgr 0)"
+    echo "$(tput setaf 3)    - postgres$(tput sgr 0)"
+    echo "$(tput setaf 3)    - pyenv-virtualenvwrapper$(tput sgr 0)"
+fi
 
 # 
 # make the environment changes stick

--- a/bin/start_dev_env.sh
+++ b/bin/start_dev_env.sh
@@ -13,14 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DJANGO_SETTINGS_MODULE=goldstone.settings.docker_dev
-STACK_VM="RDO-kilo"
-DOCKER_VM="default"
-APP_LOCATION="container"
-APP_EDITION="oss"
-
+export DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-goldstone.settings.docker_dev}
+STACK_VM=${STACK_VM:-"RDO-kilo"}
+DOCKER_VM=${DOCKER_VM:-default}
+APP_LOCATION=${GS_APP_LOCATION:-container}
+APP_EDITION=${GS_APP_EDITION:-oss}
 TOP_DIR=${GS_PROJ_TOP_DIR:-${PROJECT_HOME}/goldstone-server}
-
 GS_APP_DIR=${TOP_DIR}/docker/goldstone-app
 
 # trap ctrl-c and call ctrl_c()
@@ -176,7 +174,7 @@ if [[ ${APP_LOCATION} == "local" ]] ; then
        echo -e "Database connection status: $status"
        sleep 5
     done
-   
+
     # allow a little time for the initial DB setup to happen
     sleep 15
 


### PR DESCRIPTION
Includes some changes to `setup_dev_env.sh` and `start_dev_env.sh` as well removing an overlooked inclusion of topology in an sdist that shouldn't have it.

We can now use a set of environment vars to control the behavior of `start_dev_env.sh`.  Sane defaults are added to your .bash_profile when running `setup_dev_env.sh`.

For a full test, you could walk through the HACKING document after moving your existing goldstone-server tree out of the way.  To avoid re-downloading the OpenStack VM, try this:

If on MacOSX with Docker in VirtualBox:

`bin/setup_dev_env.sh --no-download-ova --no-configure-vbox`

If on Linux or MacOSX with Docker Beta:

`bin/setup_dev_env.sh --docker-vm=none --no-download-ova --no-configure-vbox`