### PR TITLE
developers scripts use environment variables to determine docker engi…

### DIFF
--- a/bin/build_images.sh
+++ b/bin/build_images.sh
@@ -17,7 +17,7 @@
 # goldstone-server docker container context for build. Once copied, it
 # performs a build of the docker container, and pushes it to the repo.
 
-DOCKER_VM=default
+DOCKER_VM=${DOCKER_VM:-default}
 TOP_DIR=${GS_PROJ_TOP_DIR:-${PROJECT_HOME}/goldstone-server}
 DIST_DIR=${TOP_DIR}/dist
 

--- a/bin/configure_vbox.sh
+++ b/bin/configure_vbox.sh
@@ -26,8 +26,8 @@
 
 STACK=true
 DOCKER=true
-DOCKER_VM="default"
-OPENSTACK_VM="RDO-kilo"
+DOCKER_VM=${DOCKER_VM:-default}
+OPENSTACK_VM=${OPENSTACK_VM:-"RDO-kilo"}
 
 for arg in "$@" ; do
     case $arg in
@@ -158,7 +158,7 @@ else
 fi
 
 
-if [[ $DOCKER == "true" ]] ; then
+if [[ $DOCKER == "true" && $DOCKER_VM != "none" ]] ; then
     # Ensure the docker image is stopped
     docker-machine stop ${DOCKER_VM}
     # Restore the original ssh NAT rule if it has been deleted.  Ignore errors.

--- a/bin/push_images.sh
+++ b/bin/push_images.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOCKER_VM=default
+DOCKER_VM=${DOCKER_VM:-default}
 TOP_DIR=${GS_PROJ_TOP_DIR:-${PROJECT_HOME}/goldstone-server}
 
 

--- a/bin/wipe_docker.sh
+++ b/bin/wipe_docker.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOCKER_VM=default
+DOCKER_VM=${DOCKER_VM:-default}
 
 for arg in "$@" ; do
     case $arg in
@@ -33,7 +33,7 @@ for arg in "$@" ; do
     esac
 done
 
-if [[ ${DOCKER_VM} != "false" ]] ; then
+if [[ ${DOCKER_VM} != "none" ]] ; then
     docker-machine start ${DOCKER_VM}
     eval "$(docker-machine env ${DOCKER_VM})"
 fi


### PR DESCRIPTION
…ne and Openstack instance to operate on

assumes:
DOCKER_VM=default
OPENSTACK_VM="RDO-kilo"

tested with:
DOCKER_VM=none

Which should work with Linux and MacOSX beta versions of docker.

Closes: #530 