### PR TITLE
Browser resize refresh

### DIFF
--- a/client/js/preload/goldstoneRouter.js
+++ b/client/js/preload/goldstoneRouter.js
@@ -55,12 +55,19 @@ var GoldstoneRouter = Backbone.Router.extend({
         });
         return options;
     },
+    refreshViewAfterResize: function(){
+
+        // listener instantiated in init.js
+        if(!this.currentRawViewObject) {
+            return;
+        }
+        this.switchView(this.currentRawViewObject);
+    },
     switchView: function(view) {
 
         // keep this in case browser is resized
         // it will be used to redraw view
-        // listener instantiated in init.js
-        goldstone.currentRawViewObject = view;
+        this.currentRawViewObject = view;
 
         // Capture any extra params that are passed in via the
         // router functions below, such as {node_uuid: nodeId} in

--- a/client/js/preload/goldstoneRouter.js
+++ b/client/js/preload/goldstoneRouter.js
@@ -57,6 +57,11 @@ var GoldstoneRouter = Backbone.Router.extend({
     },
     switchView: function(view) {
 
+        // keep this in case browser is resized
+        // it will be used to redraw view
+        // listener instantiated in init.js
+        goldstone.currentRawViewObject = view;
+
         // Capture any extra params that are passed in via the
         // router functions below, such as {node_uuid: nodeId} in
         // nodeReport.

--- a/client/js/preload/init.js
+++ b/client/js/preload/init.js
@@ -119,6 +119,6 @@ goldstone.init = function() {
     // debounce will activate after a cluster of resizing activity finishes
     // and there is a 400 millisecond gap.
     $(window).on('resize', _.debounce(function() {
-        goldstone.gsRouter.switchView(goldstone.currentRawViewObject);
+        goldstone.gsRouter.refreshViewAfterResize();
     }, 400));
 };

--- a/client/js/preload/init.js
+++ b/client/js/preload/init.js
@@ -116,4 +116,9 @@ goldstone.init = function() {
     // start the backbone router that will handle /# calls
     Backbone.history.start();
 
+    // debounce will activate after a cluster of resizing activity finishes
+    // and there is a 400 millisecond gap.
+    $(window).on('resize', _.debounce(function() {
+        goldstone.gsRouter.switchView(goldstone.currentRawViewObject);
+    }, 400));
 };

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -1356,12 +1356,19 @@ var GoldstoneRouter = Backbone.Router.extend({
         });
         return options;
     },
+    refreshViewAfterResize: function(){
+
+        // listener instantiated in init.js
+        if(!this.currentRawViewObject) {
+            return;
+        }
+        this.switchView(this.currentRawViewObject);
+    },
     switchView: function(view) {
 
         // keep this in case browser is resized
         // it will be used to redraw view
-        // listener instantiated in init.js
-        goldstone.currentRawViewObject = view;
+        this.currentRawViewObject = view;
 
         // Capture any extra params that are passed in via the
         // router functions below, such as {node_uuid: nodeId} in
@@ -13170,6 +13177,6 @@ goldstone.init = function() {
     // debounce will activate after a cluster of resizing activity finishes
     // and there is a 400 millisecond gap.
     $(window).on('resize', _.debounce(function() {
-        goldstone.gsRouter.switchView(goldstone.currentRawViewObject);
+        goldstone.gsRouter.refreshViewAfterResize();
     }, 400));
 };

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -1358,6 +1358,11 @@ var GoldstoneRouter = Backbone.Router.extend({
     },
     switchView: function(view) {
 
+        // keep this in case browser is resized
+        // it will be used to redraw view
+        // listener instantiated in init.js
+        goldstone.currentRawViewObject = view;
+
         // Capture any extra params that are passed in via the
         // router functions below, such as {node_uuid: nodeId} in
         // nodeReport.
@@ -13162,4 +13167,9 @@ goldstone.init = function() {
     // start the backbone router that will handle /# calls
     Backbone.history.start();
 
+    // debounce will activate after a cluster of resizing activity finishes
+    // and there is a 400 millisecond gap.
+    $(window).on('resize', _.debounce(function() {
+        goldstone.gsRouter.switchView(goldstone.currentRawViewObject);
+    }, 400));
 };

--- a/test/integration/goldstoneRouter_integrationTests.js
+++ b/test/integration/goldstoneRouter_integrationTests.js
@@ -76,5 +76,19 @@ describe('goldstoneRouter.js spec', function() {
             expect(tranlateSpy.callCount).to.equal(11);
             tranlateSpy.restore();
         });
+        it('responds properly to window resize events and re-renders the current view', function() {
+            var switchViewSpy = sinon.spy(this.testRouter, "refreshViewAfterResize");
+            expect(switchViewSpy.callCount).to.equal(0);
+            var originalView = this.testRouter.currentRawViewObject;
+            this.testRouter.apiBrowser();
+            expect(switchViewSpy.callCount).to.equal(0);
+            var currentView = this.testRouter.currentRawViewObject;
+            this.testRouter.refreshViewAfterResize();
+            var refreshedView = this.testRouter.currentRawViewObject;
+            expect(switchViewSpy.callCount).to.equal(1);
+            expect(refreshedView).to.equal(currentView);
+            expect(refreshedView).to.not.equal(originalView);
+            switchViewSpy.restore();
+        });
     });
 });


### PR DESCRIPTION
screen recording: https://slack-files.com/T02540F07-F16TUSH37-a29d1e0181

This pull request implements a debounced event listener for window resize events which will reload the current browser view.
This solves the issue of chart axes being messed up after a browser resize.

Thank you @jbc0 for the issue ticket.

closes #546 