### PR TITLE
adjusted openstack trace pattern to include start of line

### DIFF
--- a/docker/goldstone-log/logstash/patterns/goldstone
+++ b/docker/goldstone-log/logstash/patterns/goldstone
@@ -49,7 +49,7 @@ RAW_TRACE (?:^[^0-9].*$|^$)
 # treat errors separately to account for trace following
 # todo(jxstanford) review for appropriateness when working on issue-537
 OPENSTACK_ERROR %{TIMESTAMP_ISO8601:timestamp} %{POSINT:pid:int} ERROR %{OPENSTACK_SOURCE:program} %{GREEDYDATA:openstack_error_message}
-OPENSTACK_TRACE %{TIMESTAMP_ISO8601} %{POSINT} TRACE %{OPENSTACK_SOURCE} %{GREEDYDATA:openstack_trace_message}
+OPENSTACK_TRACE ^%{TIMESTAMP_ISO8601} %{POSINT} TRACE %{OPENSTACK_SOURCE} %{GREEDYDATA:openstack_trace_message}
 
 # another special case
 # todo(jxstanford) confirm that this doesn't change with rfc5424


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Reviewers
<!--- Call out additional reviewers -->
<!--- in addition to the assigned reviewer -->
<!--- example: @heyYou -->
@vichargrave 

## Description
<!--- Describe your changes in detail -->
In Centos71, rsyslog connects to journald and takes messages from there.  TRACE messages coming through journal have already been handled by some multiline parser by the time they get put into messages.  Our multiline codec was picking them up since it was matching on a pattern midway into the message.  By adding the ^ to the pattern, we will only match the pattern when the message has not been consolidated.  Now, TRACES appear correctly, but they are not using our logstash multiline codec.  I've left it in to account for future OS handling, or cases where the journal connection has been disabled.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


<!--- You can use "closes #xxx" to automatically -->
<!--- close an issue ticket when the -->
<!--- pull request is merged -->

closes #537 
coses #542

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visual inspection of trace messages generated by borking openstack.  To do it yourself, just `systemctl stop mysqld` and it should cough up a few.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires new model migrations.
- [ ] I have executed makemigrations (if necessary).
- [ ] My change requires new docker images for development.
- [ ] I have created and pushed new docker images (if necessary).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly (if necessary).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed locally.
- [ ] Test coverage percentage has improved.
- [x] PEP8 passes (for python code).
- [ ] Pylint score has improved (for python code).

