### PR TITLE
Removes spinner in dasboard stream metrics panel when events streams is dead

### DIFF
--- a/client/js/collections/metricOverviewCollection.js
+++ b/client/js/collections/metricOverviewCollection.js
@@ -50,7 +50,6 @@ api
         var self = this;
         this.computeLookbackAndInterval(60);
 
-
         var coreUrlVars = ['logs/', 'events/', 'api-calls/'];
         var coreCalls = coreUrlVars.map(function(item) {
             return self.urlBase + item + (item === 'events/' ? self.addRange2() : self.addRange()) +
@@ -66,6 +65,19 @@ api
                 finalResult.eventData = r2[0];
                 finalResult.apiData = r3[0];
 
+                // before server has fully spun up
+                // it omits the following keys
+                // that the visualization looks for
+                var defaultSignature = {
+                    per_interval: {
+                        buckets: []
+                    }
+                };
+
+                _.each(finalResult, function(collection) {
+                    collection.aggregations = collection.aggregations || defaultSignature;
+                });
+
                 // append start/end of timestamp__range
                 finalResult.startTime = self.gte;
                 finalResult.endTime = self.epochNow;
@@ -80,6 +92,5 @@ api
                 self.trigger('error', err);
             });
     },
-
 
 });

--- a/client/js/preload/goldstoneBaseView.js
+++ b/client/js/preload/goldstoneBaseView.js
@@ -311,6 +311,25 @@ var GoldstoneBaseView = Backbone.View.extend({
         });
         result += '</div><br><br>';
         return result;
+    },
+
+    // deferred object that will resolve after all intermediate
+    // deferred objects have resolved, ***success OR failure***
+    // (standard 'when' deferred will exit upon first failure)
+    whenAll: function(deferreds) {
+
+        var lastResolved = 0;
+        var wrappedDeferreds = [];
+
+        for (var i = 0; i < deferreds.length; i++) {
+            wrappedDeferreds.push($.Deferred());
+
+            deferreds[i].always(function() { //jshint ignore:line
+                wrappedDeferreds[lastResolved++].resolve(arguments);
+            });
+        }
+
+        return $.when.apply($, wrappedDeferreds).promise();
     }
 
 });

--- a/client/js/views/loginPageView.js
+++ b/client/js/views/loginPageView.js
@@ -42,29 +42,11 @@ var LoginPageView = GoldstoneBaseView.extend({
     checkForInstalledApps: function() {
         var self = this;
 
-        // deferred object that will resolve after all intermediate
-        // deferred objects have resolved, success or failure
-        $.whenAll = function(deferreds) {
-            var lastResolved = 0;
-
-            var wrappedDeferreds = [];
-
-            for (var i = 0; i < deferreds.length; i++) {
-                wrappedDeferreds.push($.Deferred());
-
-                deferreds[i].always(function() { //jshint ignore:line
-                    wrappedDeferreds[lastResolved++].resolve(arguments);
-                });
-            }
-
-            return $.when.apply($, wrappedDeferreds).promise();
-        };
-
         // determine whether the compliance and topology modules are installed
-        $.whenAll([$.get('/compliance/'), $.get('/topology/topology/')])
+        // whenAll defined on baseView
+        this.whenAll([$.get('/compliance/'), $.get('/topology/topology/')])
             .done(
                 function(result1, result2) {
-
                     // localStorage keys for compliance and topology
                     // will be as follows, or null if call fails.
                     localStorage.setItem('compliance', result1[1] === 'success' ? JSON.stringify([{

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -584,6 +584,25 @@ var GoldstoneBaseView = Backbone.View.extend({
         });
         result += '</div><br><br>';
         return result;
+    },
+
+    // deferred object that will resolve after all intermediate
+    // deferred objects have resolved, ***success OR failure***
+    // (standard 'when' deferred will exit upon first failure)
+    whenAll: function(deferreds) {
+
+        var lastResolved = 0;
+        var wrappedDeferreds = [];
+
+        for (var i = 0; i < deferreds.length; i++) {
+            wrappedDeferreds.push($.Deferred());
+
+            deferreds[i].always(function() { //jshint ignore:line
+                wrappedDeferreds[lastResolved++].resolve(arguments);
+            });
+        }
+
+        return $.when.apply($, wrappedDeferreds).promise();
     }
 
 });
@@ -7976,29 +7995,11 @@ var LoginPageView = GoldstoneBaseView.extend({
     checkForInstalledApps: function() {
         var self = this;
 
-        // deferred object that will resolve after all intermediate
-        // deferred objects have resolved, success or failure
-        $.whenAll = function(deferreds) {
-            var lastResolved = 0;
-
-            var wrappedDeferreds = [];
-
-            for (var i = 0; i < deferreds.length; i++) {
-                wrappedDeferreds.push($.Deferred());
-
-                deferreds[i].always(function() { //jshint ignore:line
-                    wrappedDeferreds[lastResolved++].resolve(arguments);
-                });
-            }
-
-            return $.when.apply($, wrappedDeferreds).promise();
-        };
-
         // determine whether the compliance and topology modules are installed
-        $.whenAll([$.get('/compliance/'), $.get('/topology/topology/')])
+        // whenAll defined on baseView
+        this.whenAll([$.get('/compliance/'), $.get('/topology/topology/')])
             .done(
                 function(result1, result2) {
-
                     // localStorage keys for compliance and topology
                     // will be as follows, or null if call fails.
                     localStorage.setItem('compliance', result1[1] === 'success' ? JSON.stringify([{

--- a/goldstone/static/bundle/bundle.js
+++ b/goldstone/static/bundle/bundle.js
@@ -3250,7 +3250,6 @@ api
         var self = this;
         this.computeLookbackAndInterval(60);
 
-
         var coreUrlVars = ['logs/', 'events/', 'api-calls/'];
         var coreCalls = coreUrlVars.map(function(item) {
             return self.urlBase + item + (item === 'events/' ? self.addRange2() : self.addRange()) +
@@ -3266,6 +3265,19 @@ api
                 finalResult.eventData = r2[0];
                 finalResult.apiData = r3[0];
 
+                // before server has fully spun up
+                // it omits the following keys
+                // that the visualization looks for
+                var defaultSignature = {
+                    per_interval: {
+                        buckets: []
+                    }
+                };
+
+                _.each(finalResult, function(collection) {
+                    collection.aggregations = collection.aggregations || defaultSignature;
+                });
+
                 // append start/end of timestamp__range
                 finalResult.startTime = self.gte;
                 finalResult.endTime = self.epochNow;
@@ -3280,7 +3292,6 @@ api
                 self.trigger('error', err);
             });
     },
-
 
 });
 ;


### PR DESCRIPTION
## Description

Django server was omitting result keys that were required by the view prior to server fully spinning up.
This pull request creates a check for those required keys and appends them to the payload returned to the view, if necessary.
## Related Issue

closes #494 
closes #604 
## How Has This Been Tested?

Tested via shutting down the server and OpenStack instance, followed by a restart of the browser as soon as the Django server was running again. Screenshots of the desired behavior being carried out below:
## Screenshots (if appropriate):

proper failure error handling followed by no spinner
<img width="1215" alt="screen shot 2016-06-21 at 10 47 29 am" src="https://cloud.githubusercontent.com/assets/5633015/16234271/facb2e3e-379e-11e6-8906-57c84b691f2b.png">
 failure error handling duplicating the other charts
<img width="1211" alt="screen shot 2016-06-21 at 10 47 16 am" src="https://cloud.githubusercontent.com/assets/5633015/16234280/005438be-379f-11e6-9fc1-61b819f2200a.png">
 and finally followed by a successful connection to the server without lingering error states
<img width="1211" alt="screen shot 2016-06-21 at 10 47 47 am" src="https://cloud.githubusercontent.com/assets/5633015/16234286/04f81700-379f-11e6-818d-b9c5c3db907f.png">
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires new model migrations.
- [ ] I have executed makemigrations (if necessary).
- [ ] My change requires new docker images for development.
- [ ] I have created and pushed new docker images (if necessary).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly (if necessary).
- [x] visually tested and verified
- [ ] All new and existing tests passed locally.
- [ ] Test coverage percentage has improved.
- [ ] PEP8 passes (for python code).
- [ ] Pylint score has improved (for python code).
